### PR TITLE
ci: Temporarily disable publishing to GitHub Packages

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -38,14 +38,15 @@ publishing {
                 password = System.getenv('MAVEN_PASSWORD')
             }
         }
-        maven {
-            name = 'GitHubPackages'
-            url = 'https://maven.pkg.github.com/openfga/java-sdk'
-            credentials {
-                username = System.getenv('GITHUB_ACTOR')
-                password = System.getenv('GITHUB_TOKEN')
-            }
-        }
+//        // TODO: Uncomment once Maven Central publishing is verified working.
+//        maven {
+//            name = 'GitHubPackages'
+//            url = 'https://maven.pkg.github.com/openfga/java-sdk'
+//            credentials {
+//                username = System.getenv('GITHUB_ACTOR')
+//                password = System.getenv('GITHUB_TOKEN')
+//            }
+//        }
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

On the first publishing CI run, publishing to GitHub Packages succeeded, but failed for Maven Central due to a credentials issue.

This temporarily skip GH Packages publishing so we can try to get the Maven Central publish working.

If both succeed at the same time, this should be unnecessary

If we think we might ever hit one-succeeds and one-fails again, we could consider splitting the publishing workflows for the two repositories apart

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
