### PR TITLE
fix: client_credentials content type

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/auth/OAuth2Client.java
+++ b/src/main/java/dev/openfga/sdk/api/auth/OAuth2Client.java
@@ -77,7 +77,8 @@ public class OAuth2Client {
 
             Configuration config = new Configuration().apiUrl(apiTokenIssuer);
 
-            HttpRequest.Builder requestBuilder = ApiClient.requestBuilder("POST", "", body, config);
+            HttpRequest.Builder requestBuilder = ApiClient.requestBuilder("POST", "", body, config)
+                    .header("Content-Type", "application/x-www-form-urlencoded");
 
             HttpRequest request = requestBuilder.build();
 

--- a/src/test/java/dev/openfga/sdk/api/auth/OAuth2ClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/auth/OAuth2ClientTest.java
@@ -83,6 +83,7 @@ class OAuth2ClientTest {
                 .verify()
                 .post(tokenEndpointUrl)
                 .withBody(is(expectedPostBody))
+                .withHeader("Content-Type", "application/x-www-form-urlencoded")
                 .called();
         assertEquals(ACCESS_TOKEN, result);
     }


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes -->

## References

- PR by @le-yams https://github.com/openfga/sdk-generator/pull/281

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
