### PR TITLE
fix(client): fix transactions mode being reversed

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
+++ b/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
@@ -363,7 +363,7 @@ public class OpenFgaClient {
         return writeTransactions(storeId, request, options);
     }
 
-    private CompletableFuture<ClientWriteResponse> writeNonTransaction(
+    private CompletableFuture<ClientWriteResponse> writeTransactions(
             String storeId, ClientWriteRequest request, ClientWriteOptions options) {
 
         WriteRequest body = new WriteRequest();
@@ -390,7 +390,7 @@ public class OpenFgaClient {
         return call(() -> api.write(storeId, body, overrides)).thenApply(ClientWriteResponse::new);
     }
 
-    private CompletableFuture<ClientWriteResponse> writeTransactions(
+    private CompletableFuture<ClientWriteResponse> writeNonTransaction(
             String storeId, ClientWriteRequest request, ClientWriteOptions writeOptions) {
 
         var options = writeOptions != null
@@ -412,10 +412,10 @@ public class OpenFgaClient {
 
         if (transactions.isEmpty()) {
             var emptyTransaction = new ClientWriteRequest().writes(null).deletes(null);
-            return this.writeNonTransaction(storeId, emptyTransaction, writeOptions);
+            return this.writeTransactions(storeId, emptyTransaction, writeOptions);
         }
 
-        var futureResponse = this.writeNonTransaction(storeId, transactions.get(0), options);
+        var futureResponse = this.writeTransactions(storeId, transactions.get(0), options);
 
         for (int i = 1; i < transactions.size(); i++) {
             final int index = i; // Must be final in this scope for closure.
@@ -424,7 +424,7 @@ public class OpenFgaClient {
             // 1. The first exception thrown in a failed completion. Other thenCompose() will not be evaluated.
             // 2. The final successful ClientWriteResponse.
             futureResponse = futureResponse.thenCompose(
-                    _response -> this.writeNonTransaction(storeId, transactions.get(index), options));
+                    _response -> this.writeTransactions(storeId, transactions.get(index), options));
         }
 
         return futureResponse;

--- a/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
@@ -1106,7 +1106,7 @@ public class OpenFgaClientTest {
     }
 
     @Test
-    public void writeTest_transactions() throws Exception {
+    public void writeTest_nonTransaction() throws Exception {
         // Given
         String postPath = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write";
         String writeTupleBody = String.format(
@@ -1142,7 +1142,7 @@ public class OpenFgaClientTest {
                 .writes(List.of(writeTuple, writeTuple, writeTuple, writeTuple, writeTuple))
                 .deletes(List.of(tuple, tuple, tuple, tuple, tuple));
         ClientWriteOptions options =
-                new ClientWriteOptions().disableTransactions(false).transactionChunkSize(2);
+                new ClientWriteOptions().disableTransactions(true).transactionChunkSize(2);
 
         // When
         var response = fga.write(request, options).get();
@@ -1180,7 +1180,7 @@ public class OpenFgaClientTest {
     }
 
     @Test
-    public void writeTest_transactionsWithFailure() throws Exception {
+    public void writeTest_nonTransactionsWithFailure() {
         // Given
         String postPath = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write";
         String firstUser = "user:first";
@@ -1210,7 +1210,7 @@ public class OpenFgaClientTest {
                                 .condition(DEFAULT_CONDITION))
                         .collect(Collectors.toList()));
         ClientWriteOptions options =
-                new ClientWriteOptions().disableTransactions(false).transactionChunkSize(1);
+                new ClientWriteOptions().disableTransactions(true).transactionChunkSize(1);
 
         // When
         var execException = assertThrows(
@@ -1243,7 +1243,7 @@ public class OpenFgaClientTest {
     }
 
     @Test
-    public void writeTest_nonTransaction() throws Exception {
+    public void writeTest_transaction() throws Exception {
         // Given
         String postPath = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write";
         String writeTupleBody = String.format(
@@ -1272,7 +1272,7 @@ public class OpenFgaClientTest {
 
         // We expect transactionChunkSize will be ignored, and exactly one request will be sent.
         ClientWriteOptions options =
-                new ClientWriteOptions().disableTransactions(true).transactionChunkSize(1);
+                new ClientWriteOptions().disableTransactions(false).transactionChunkSize(1);
 
         // When
         var response = fga.write(request, options).get();
@@ -1283,7 +1283,7 @@ public class OpenFgaClientTest {
     }
 
     @Test
-    public void writeTest_nonTransactionsWithFailure() throws Exception {
+    public void writeTest_transactionWithFailure() {
         // Given
         String postPath = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write";
         String writeTupleBody = String.format(
@@ -1315,7 +1315,7 @@ public class OpenFgaClientTest {
 
         // We expect transactionChunkSize will be ignored, and exactly one request will be sent.
         ClientWriteOptions options =
-                new ClientWriteOptions().disableTransactions(true).transactionChunkSize(1);
+                new ClientWriteOptions().disableTransactions(false).transactionChunkSize(1);
 
         // When
         var execException = assertThrows(


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
⚠️ This is a behavioral breaking change!

Currently the `OpenFgaClient` reverses the behavior of write transactions based on the `disableTransactions` flag. This PR fixes that, only sending batched write requests if `disableTransactions == true`.

This is a functional breaking change, since the value of `disableTransactions` was being used incorrectly, so now `disableTransactions == true` will actually batch requests, and `disableTransactions == false` will send one (transactional) request.

## References
- Generated from https://github.com/openfga/sdk-generator/pull/321
- Fixes #59 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
