### PR TITLE
chore: use Testcontainers OpenFGA module for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,8 @@ testing {
             dependencies {
                 implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
                 implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
+                implementation "org.testcontainers:junit-jupiter:1.19.7"
+                implementation "org.testcontainers:openfga:1.19.7"
                 implementation project()
             }
 

--- a/src/test-integration/java/dev/openfga/sdk/api/OpenFgaApiIntegrationTest.java
+++ b/src/test-integration/java/dev/openfga/sdk/api/OpenFgaApiIntegrationTest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.openfga.sdk.api.client.model.*;
 import dev.openfga.sdk.api.configuration.*;
 import dev.openfga.sdk.api.model.*;
 import java.io.IOException;
@@ -28,9 +27,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.openfga.OpenFGAContainer;
 
 @TestInstance(Lifecycle.PER_CLASS)
+@Testcontainers
 public class OpenFgaApiIntegrationTest {
+
+    @Container
+    private static final OpenFGAContainer openfga = new OpenFGAContainer("openfga/openfga:v1.5.0");
+
     private static final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
     private static final String DEFAULT_USER = "user:81684243-9356-4421-8fbf-a4f8d36aa31b";
     private static final String DEFAULT_DOC = "document:2021-budget";
@@ -50,7 +57,7 @@ public class OpenFgaApiIntegrationTest {
     public void initializeApi() throws Exception {
         System.setProperty("HttpRequestAttempt.debug-logging", "enable");
 
-        Configuration apiConfig = new Configuration().apiUrl("http://localhost:8080");
+        Configuration apiConfig = new Configuration().apiUrl(openfga.getHttpEndpoint());
         api = new OpenFgaApi(apiConfig);
     }
 

--- a/src/test-integration/java/dev/openfga/sdk/api/client/OpenFgaClientIntegrationTest.java
+++ b/src/test-integration/java/dev/openfga/sdk/api/client/OpenFgaClientIntegrationTest.java
@@ -28,9 +28,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.openfga.OpenFGAContainer;
 
 @TestInstance(Lifecycle.PER_CLASS)
+@Testcontainers
 public class OpenFgaClientIntegrationTest {
+
+    @Container
+    private static final OpenFGAContainer openfga = new OpenFGAContainer("openfga/openfga:v1.5.0");
+
     private static final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
     private static final String DEFAULT_USER = "user:81684243-9356-4421-8fbf-a4f8d36aa31b";
     private static final String DEFAULT_DOC = "document:2021-budget";
@@ -62,7 +70,7 @@ public class OpenFgaClientIntegrationTest {
     public void initializeApi() throws Exception {
         System.setProperty("HttpRequestAttempt.debug-logging", "enable");
 
-        ClientConfiguration apiConfig = new ClientConfiguration().apiUrl("http://localhost:8080");
+        ClientConfiguration apiConfig = new ClientConfiguration().apiUrl(openfga.getHttpEndpoint());
         fga = new OpenFgaClient(apiConfig);
     }
 


### PR DESCRIPTION
Testcontainers 1.19.7 provides `OpenFGA` module, which can be used for local testing.

The only requirement is Docker improving the DevEX.
