### PR TITLE
feat: support context and contextual tuples on listrelations

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
+++ b/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
@@ -679,6 +679,9 @@ public class OpenFgaClient {
                 var bodyContextualTuples = ClientTupleKey.asContextualTupleKeys(contextualTuples);
                 body.contextualTuples(bodyContextualTuples);
             }
+            if (request.getContext() != null) {
+                body.context(request.getContext());
+            }
         }
 
         if (options != null && !isNullOrWhitespace(options.getAuthorizationModelId())) {

--- a/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
+++ b/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
@@ -726,7 +726,9 @@ public class OpenFgaClient {
                 .map(relation -> new ClientCheckRequest()
                         .user(request.getUser())
                         .relation(relation)
-                        ._object(request.getObject()))
+                        ._object(request.getObject())
+                        .contextualTuples(request.getContextualTupleKeys())
+                        .context(request.getContext()))
                 .collect(Collectors.toList());
 
         return this.batchCheck(batchCheckRequests, options.asClientBatchCheckOptions())

--- a/src/main/java/dev/openfga/sdk/api/client/model/ClientListObjectsRequest.java
+++ b/src/main/java/dev/openfga/sdk/api/client/model/ClientListObjectsRequest.java
@@ -19,6 +19,7 @@ public class ClientListObjectsRequest {
     private String relation;
     private String type;
     private List<ClientTupleKey> contextualTupleKeys;
+    private Object context;
 
     public ClientListObjectsRequest user(String user) {
         this.user = user;
@@ -62,5 +63,14 @@ public class ClientListObjectsRequest {
 
     public List<ClientTupleKey> getContextualTupleKeys() {
         return contextualTupleKeys;
+    }
+
+    public ClientListObjectsRequest context(Object context) {
+        this.context = context;
+        return this;
+    }
+
+    public Object getContext() {
+        return context;
     }
 }

--- a/src/main/java/dev/openfga/sdk/api/client/model/ClientListRelationsRequest.java
+++ b/src/main/java/dev/openfga/sdk/api/client/model/ClientListRelationsRequest.java
@@ -19,6 +19,7 @@ public class ClientListRelationsRequest {
     private String _object;
     private List<String> relations;
     private List<ClientTupleKey> contextualTupleKeys;
+    private Object context;
 
     public ClientListRelationsRequest user(String user) {
         this.user = user;
@@ -62,5 +63,18 @@ public class ClientListRelationsRequest {
 
     public List<ClientTupleKey> getContextualTupleKeys() {
         return contextualTupleKeys;
+    }
+
+    public ClientListRelationsRequest context(Object context) {
+        this.context = context;
+        return this;
+    }
+
+    /**
+     * Get context
+     * @return context
+     **/
+    public Object getContext() {
+        return context;
     }
 }

--- a/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
@@ -1975,6 +1975,30 @@ public class OpenFgaClientTest {
                 "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseData());
     }
 
+    @Test
+    public void listObjectsWithContextTest() throws Exception {
+        // Given
+        String postPath = String.format("https://localhost/stores/%s/list-objects", DEFAULT_STORE_ID);
+        String expectedBody = String.format(
+                "{\"authorization_model_id\":\"%s\",\"type\":null,\"relation\":\"%s\",\"user\":\"%s\",\"contextual_tuples\":null,\"context\":{\"some\":\"context\"}}",
+                DEFAULT_AUTH_MODEL_ID, DEFAULT_RELATION, DEFAULT_USER);
+        mockHttpClient
+                .onPost(postPath)
+                .withBody(is(expectedBody))
+                .doReturn(200, String.format("{\"objects\":[\"%s\"]}", DEFAULT_OBJECT));
+        ClientListObjectsRequest request = new ClientListObjectsRequest()
+                .relation(DEFAULT_RELATION)
+                .user(DEFAULT_USER)
+                .context(Map.of("some", "context"));
+
+        // When
+        ClientListObjectsResponse response = fga.listObjects(request).get();
+
+        // Then
+        mockHttpClient.verify().post(postPath).withBody(is(expectedBody)).called(1);
+        assertEquals(List.of(DEFAULT_OBJECT), response.getObjects());
+    }
+
     /**
      * Check whether a user is authorized to access an object.
      */


### PR DESCRIPTION
## Description

Adds support for passing context and contextual tuples to a `listRelations` call. Also copies across the context change for `listObjects` and adds a test for this.

## References

Generated from openfga/sdk-generator/pull/332 and openfga/sdk-generator/issues/341

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
