### PR TITLE
test: extend tests for access token validity check

### DIFF
--- a/src/test/java/dev/openfga/sdk/api/auth/AccessTokenTest.java
+++ b/src/test/java/dev/openfga/sdk/api/auth/AccessTokenTest.java
@@ -35,11 +35,11 @@ class AccessTokenTest {
                         Instant.now().minus(1, ChronoUnit.HOURS),
                         false),
                 Arguments.of(
-                        "Expired 10 minutes should not not be valid",
+                        "Expired 10 minutes ago should not not be valid",
                         Instant.now().minus(10, ChronoUnit.MINUTES),
                         false),
                 Arguments.of(
-                        "Expired 5 minutes should not not be valid",
+                        "Expired 5 minutes ago should not not be valid",
                         Instant.now().minus(5, ChronoUnit.MINUTES),
                         false),
                 Arguments.of(

--- a/src/test/java/dev/openfga/sdk/api/auth/AccessTokenTest.java
+++ b/src/test/java/dev/openfga/sdk/api/auth/AccessTokenTest.java
@@ -25,16 +25,34 @@ class AccessTokenTest {
 
     private static Stream<Arguments> expTimeAndResults() {
         return Stream.of(
-                Arguments.of(Instant.now().plus(1, ChronoUnit.HOURS), true),
-                Arguments.of(Instant.now().minus(1, ChronoUnit.HOURS), false),
-                Arguments.of(Instant.now().minus(10, ChronoUnit.MINUTES), false),
-                Arguments.of(Instant.now().plus(10, ChronoUnit.MINUTES), true),
-                Arguments.of(Instant.now(), true));
+                Arguments.of("Expires in 1 hour should be valid", Instant.now().plus(1, ChronoUnit.HOURS), true),
+                Arguments.of(
+                        "Expires in 10 minutes should be valid", Instant.now().plus(10, ChronoUnit.MINUTES), true),
+                Arguments.of(
+                        "Expires in 6 minutes should be valid", Instant.now().plus(6, ChronoUnit.MINUTES), true),
+                Arguments.of(
+                        "Expired 1 hour ago should not not be valid",
+                        Instant.now().minus(1, ChronoUnit.HOURS),
+                        false),
+                Arguments.of(
+                        "Expired 10 minutes should not not be valid",
+                        Instant.now().minus(10, ChronoUnit.MINUTES),
+                        false),
+                Arguments.of(
+                        "Expired 5 minutes should not not be valid",
+                        Instant.now().minus(5, ChronoUnit.MINUTES),
+                        false),
+                Arguments.of(
+                        "Expires in 5 minutes should not not be valid",
+                        Instant.now().plus(5, ChronoUnit.MINUTES),
+                        false),
+                Arguments.of("Expires now should not not be valid", Instant.now(), false),
+                Arguments.of("Not set should not not be valid", null, false));
     }
 
     @MethodSource("expTimeAndResults")
-    @ParameterizedTest
-    public void testTokenValid(Instant exp, boolean valid) {
+    @ParameterizedTest(name = "{0}")
+    public void testTokenValid(String name, Instant exp, boolean valid) {
         AccessToken accessToken = new AccessToken();
         accessToken.setToken("token");
         accessToken.setExpiresAt(exp);


### PR DESCRIPTION
## Description

* 1d2096094a1cde87ef0fbd10a676987e9e004786 - Extends the testing of the token validity check to include checks for closer to the expiry time (expires in 6 minutes, 5 minutes)
* 2084b0ab0bd2a6ca4836a79bb945cf6778244398 - Refactors the validity check to split it out into separate null checks and time checks.

I've removed the jitter here as I'm not sure what it added and it made testing harder as we didn't have predictability. If we want to guard against a potential "thundering herd" on the token refresh then I think we'd be better off attempting to only allow one call to the token endpoints to occur at a time (not sure how to do this in Java myself, maybe if we used [synchronized](https://docs.oracle.com/javase/tutorial/essential/concurrency/syncmeth.html) on `exchangeToken`?

## References

Resolves #75 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
