### PR TITLE
feat: support OpenTelemetry metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "org.openapitools:jackson-databind-nullable:0.2.6"
+    implementation platform("io.opentelemetry:opentelemetry-bom:1.40.0")
+    implementation "io.opentelemetry:opentelemetry-api"
 }
 
 testing {

--- a/src/main/java/dev/openfga/sdk/telemetry/Attribute.java
+++ b/src/main/java/dev/openfga/sdk/telemetry/Attribute.java
@@ -1,0 +1,26 @@
+package dev.openfga.sdk.telemetry;
+
+/**
+ * Represents an attribute in telemetry data.
+ */
+public class Attribute {
+    private final String name;
+
+    /**
+     * Constructs a new Attribute object with the specified name.
+     *
+     * @param name the name of the attribute
+     */
+    public Attribute(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Returns the name of the attribute.
+     *
+     * @return the name of the attribute
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/dev/openfga/sdk/telemetry/Attributes.java
+++ b/src/main/java/dev/openfga/sdk/telemetry/Attributes.java
@@ -1,0 +1,142 @@
+package dev.openfga.sdk.telemetry;
+
+import dev.openfga.sdk.api.client.ApiResponse;
+import dev.openfga.sdk.api.configuration.Credentials;
+import dev.openfga.sdk.api.configuration.CredentialsMethod;
+import io.opentelemetry.api.common.AttributeKey;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class represents a collection of attributes used for telemetry purposes.
+ */
+public class Attributes {
+    /**
+     * Attribute representing the model ID of a request.
+     */
+    public static final Attribute REQUEST_MODEL_ID = new Attribute("fga-client.request.model_id");
+
+    /**
+     * Attribute representing the method of a request.
+     */
+    public static final Attribute REQUEST_METHOD = new Attribute("fga-client.request.method");
+
+    /**
+     * Attribute representing the store ID of a request.
+     */
+    public static final Attribute REQUEST_STORE_ID = new Attribute("fga-client.request.store_id");
+
+    /**
+     * Attribute representing the client ID of a request.
+     */
+    public static final Attribute REQUEST_CLIENT_ID = new Attribute("fga-client.request.client_id");
+
+    /**
+     * Attribute representing the number of retries for a request.
+     */
+    public static final Attribute REQUEST_RETRIES = new Attribute("fga-client.request.retries");
+
+    /**
+     * Attribute representing the model ID of a response.
+     */
+    public static final Attribute RESPONSE_MODEL_ID = new Attribute("fga-client.response.model_id");
+
+    /**
+     * Attribute representing the user of a client.
+     */
+    public static final Attribute CLIENT_USER = new Attribute("fga-client.user");
+
+    /**
+     * Attribute representing the host of an HTTP request.
+     */
+    public static final Attribute HTTP_HOST = new Attribute("http.host");
+
+    /**
+     * Attribute representing the method of an HTTP request.
+     */
+    public static final Attribute HTTP_METHOD = new Attribute("http.method");
+
+    /**
+     * Attribute representing the status code of an HTTP response.
+     */
+    public static final Attribute HTTP_STATUS_CODE = new Attribute("http.status_code");
+
+    /**
+     * Prepares the attributes for OpenTelemetry publishing by converting them into the expected format.
+     *
+     * @param attributes the attributes to prepare
+     *
+     * @return the prepared attributes
+     */
+    public static io.opentelemetry.api.common.Attributes prepare(Map<Attribute, String> attributes) {
+        io.opentelemetry.api.common.AttributesBuilder builder = io.opentelemetry.api.common.Attributes.builder();
+
+        attributes.forEach((key, value) -> {
+            builder.put(AttributeKey.stringKey(key.getName()), value);
+        });
+
+        return builder.build();
+    }
+
+    /**
+     * Converts an HTTP response and credentials into a map of attributes for telemetry purposes.
+     *
+     * @param response    the HTTP response
+     * @param credentials the credentials
+     *
+     * @return the map of formatted attributes
+     */
+    public static Map<Attribute, String> fromHttpResponse(HttpResponse<?> response, Credentials credentials) {
+        Map<Attribute, String> attributes = new HashMap<>();
+
+        if (response != null) {
+            attributes.put(HTTP_STATUS_CODE, String.valueOf(response.statusCode()));
+
+            String responseModelId = response.headers()
+                    .firstValue("openfga-authorization-model-id")
+                    .orElse(null);
+
+            if (responseModelId != null) {
+                attributes.put(RESPONSE_MODEL_ID, responseModelId);
+            }
+        }
+
+        if (credentials != null && credentials.getCredentialsMethod() == CredentialsMethod.CLIENT_CREDENTIALS) {
+            attributes.put(REQUEST_CLIENT_ID, credentials.getClientCredentials().getClientId());
+        }
+
+        return attributes;
+    }
+
+    /**
+     * Converts an API response and credentials into a map of attributes for telemetry purposes.
+     *
+     * @param response    the API response
+     * @param credentials the credentials
+     *
+     * @return the map of formatted attributes
+     */
+    public static Map<Attribute, String> fromApiResponse(ApiResponse<?> response, Credentials credentials) {
+        Map<Attribute, String> attributes = new HashMap<>();
+
+        if (response != null) {
+            attributes.put(HTTP_STATUS_CODE, String.valueOf(response.getStatusCode()));
+
+            List<String> responseModelIdList =
+                    response.getHeaders().getOrDefault("openfga-authorization-model-id", null);
+            String responseModelId = responseModelIdList != null ? responseModelIdList.get(0) : null;
+
+            if (responseModelId != null) {
+                attributes.put(RESPONSE_MODEL_ID, responseModelId);
+            }
+        }
+
+        if (credentials != null && credentials.getCredentialsMethod() == CredentialsMethod.CLIENT_CREDENTIALS) {
+            attributes.put(REQUEST_CLIENT_ID, credentials.getClientCredentials().getClientId());
+        }
+
+        return attributes;
+    }
+}

--- a/src/main/java/dev/openfga/sdk/telemetry/Counter.java
+++ b/src/main/java/dev/openfga/sdk/telemetry/Counter.java
@@ -1,0 +1,50 @@
+package dev.openfga.sdk.telemetry;
+
+/**
+ * Represents a counter used for telemetry purposes.
+ */
+public class Counter {
+    private final String name;
+    private final String unit;
+    private final String description;
+
+    /**
+     * Constructs a new Counter with the specified name, unit, and description.
+     *
+     * @param name        the name of the counter
+     * @param unit        the unit of measurement for the counter
+     * @param description the description of the counter
+     */
+    public Counter(String name, String unit, String description) {
+        this.name = name;
+        this.unit = unit;
+        this.description = description;
+    }
+
+    /**
+     * Returns the name of the counter.
+     *
+     * @return the name of the counter
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the unit of measurement for the counter.
+     *
+     * @return the unit of measurement for the counter
+     */
+    public String getUnit() {
+        return unit;
+    }
+
+    /**
+     * Returns the description of the counter.
+     *
+     * @return the description of the counter
+     */
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/dev/openfga/sdk/telemetry/Counters.java
+++ b/src/main/java/dev/openfga/sdk/telemetry/Counters.java
@@ -1,0 +1,12 @@
+package dev.openfga.sdk.telemetry;
+
+/**
+ * The Counters class represents telemetry counters used in the OpenFGA SDK.
+ */
+public class Counters {
+    /**
+     * The CREDENTIALS_REQUEST counter represents the number of times an access token is requested.
+     */
+    public static final Counter CREDENTIALS_REQUEST = new Counter(
+            "fga-client.credentials.request", "milliseconds", "The number of times an access token is requested.");
+}

--- a/src/main/java/dev/openfga/sdk/telemetry/Histogram.java
+++ b/src/main/java/dev/openfga/sdk/telemetry/Histogram.java
@@ -1,0 +1,44 @@
+package dev.openfga.sdk.telemetry;
+
+/**
+ * Represents a histogram for telemetry data.
+ */
+public class Histogram {
+    private final String name;
+    private final String unit;
+    private final String description;
+
+    /**
+     * Constructs a Histogram object with the specified name, unit, and description.
+     *
+     * @param name        the name of the histogram
+     * @param unit        the unit of measurement for the histogram
+     * @param description the description of the histogram
+     */
+    public Histogram(String name, String unit, String description) {
+        this.name = name;
+        this.unit = unit;
+        this.description = description;
+    }
+
+    /**
+     * Returns the name of the histogram.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the unit of measurement for the histogram.
+     */
+    public String getUnit() {
+        return unit;
+    }
+
+    /**
+     * Returns the description of the histogram.
+     */
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/dev/openfga/sdk/telemetry/Histograms.java
+++ b/src/main/java/dev/openfga/sdk/telemetry/Histograms.java
@@ -1,0 +1,18 @@
+package dev.openfga.sdk.telemetry;
+
+/**
+ * The Histograms class represents a collection of predefined histograms for telemetry purposes.
+ */
+public class Histograms {
+    /**
+     * A histogram for measuring the duration of a request.
+     */
+    public static final Histogram REQUEST_DURATION = new Histogram(
+            "fga-client.request.duration", "milliseconds", "How long it took for a request to be fulfilled.");
+
+    /**
+     * A histogram for measuring the duration of a query request.
+     */
+    public static final Histogram QUERY_DURATION =
+            new Histogram("fga-client.query.duration", "milliseconds", "How long it took to perform a query request.");
+}

--- a/src/main/java/dev/openfga/sdk/telemetry/Metrics.java
+++ b/src/main/java/dev/openfga/sdk/telemetry/Metrics.java
@@ -1,0 +1,119 @@
+package dev.openfga.sdk.telemetry;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The Metrics class provides methods for creating and publishing metrics using OpenTelemetry.
+ */
+public class Metrics {
+
+    private final Meter meter;
+    private final Map<String, LongCounter> counters;
+    private final Map<String, DoubleHistogram> histograms;
+
+    public Metrics() {
+        this.meter = OpenTelemetry.noop().getMeterProvider().get("openfga-sdk/0.5.0");
+        this.counters = new HashMap<>();
+        this.histograms = new HashMap<>();
+    }
+
+    /**
+     * Returns the Meter associated with this Metrics session.
+     *
+     * @return The Meter object.
+     */
+    public Meter getMeter() {
+        return meter;
+    }
+
+    /**
+     * Returns a LongCounter metric instance.
+     *
+     * @param counter    The Counter enum representing the metric.
+     * @param value      The value to be added to the counter.
+     * @param attributes A map of attributes associated with the metric.
+     *
+     * @return The LongCounter metric instance.
+     */
+    public LongCounter getCounter(Counter counter, Long value, Map<Attribute, String> attributes) {
+        if (!counters.containsKey(counter.getName())) {
+            counters.put(
+                    counter.getName(),
+                    meter.counterBuilder(counter.getName())
+                            .setDescription(counter.getDescription())
+                            .setUnit(counter.getUnit())
+                            .build());
+        }
+
+        LongCounter counterInstance = counters.get(counter.getName());
+
+        if (value != null) {
+            counterInstance.add(value, Attributes.prepare(attributes));
+        }
+
+        return counterInstance;
+    }
+
+    /**
+     * Returns a DoubleHistogram metric instance.
+     *
+     * @param histogram  The Histogram enum representing the metric.
+     * @param value      The value to be recorded in the histogram.
+     * @param attributes A map of attributes associated with the metric.
+     */
+    public DoubleHistogram getHistogram(Histogram histogram, Double value, Map<Attribute, String> attributes) {
+        if (!histograms.containsKey(histogram.getName())) {
+            histograms.put(
+                    histogram.getName(),
+                    meter.histogramBuilder(histogram.getName())
+                            .setDescription(histogram.getDescription())
+                            .setUnit(histogram.getUnit())
+                            .build());
+        }
+
+        DoubleHistogram histogramInstance = histograms.get(histogram.getName());
+
+        if (value != null) {
+            histogramInstance.record(value, Attributes.prepare(attributes));
+        }
+
+        return histogramInstance;
+    }
+
+    /**
+     * Returns a LongCounter metric instance, for publishing the number of times an access token is requested.
+     *
+     * @param value      The value to be added to the counter.
+     * @param attributes A map of attributes associated with the metric.
+     *
+     * @return The LongCounter metric instance for credentials request.
+     */
+    public LongCounter credentialsRequest(Long value, Map<Attribute, String> attributes) {
+        return getCounter(Counters.CREDENTIALS_REQUEST, value, attributes);
+    }
+
+    /**
+     * Returns a DoubleHistogram metric instance, for publishing the duration of requests.
+     *
+     * @param value      The value to be recorded in the histogram.
+     * @param attributes A map of attributes associated with the metric.
+     */
+    public DoubleHistogram requestDuration(Double value, Map<Attribute, String> attributes) {
+        return getHistogram(Histograms.REQUEST_DURATION, value, attributes);
+    }
+
+    /**
+     * Returns a DoubleHistogram metric instance, for publishing the duration of queries.
+     *
+     * @param value      The value to be recorded in the histogram.
+     * @param attributes A map of attributes associated with the metric.
+     */
+    public DoubleHistogram queryDuration(Double value, Map<Attribute, String> attributes) {
+        return getHistogram(Histograms.QUERY_DURATION, value, attributes);
+    }
+}

--- a/src/main/java/dev/openfga/sdk/telemetry/Telemetry.java
+++ b/src/main/java/dev/openfga/sdk/telemetry/Telemetry.java
@@ -1,0 +1,20 @@
+package dev.openfga.sdk.telemetry;
+
+/**
+ * The Telemetry class provides access to telemetry-related functionality.
+ */
+public class Telemetry {
+    private Metrics metrics = null;
+
+    /**
+     * Returns the Metrics object for collecting telemetry data.
+     * If the Metrics object has not been initialized, it will be created.
+     */
+    public Metrics metrics() {
+        if (metrics == null) {
+            metrics = new Metrics();
+        }
+
+        return metrics;
+    }
+}

--- a/src/test/java/dev/openfga/sdk/api/OpenFgaApiTest.java
+++ b/src/test/java/dev/openfga/sdk/api/OpenFgaApiTest.java
@@ -1328,7 +1328,6 @@ public class OpenFgaApiTest {
         var response = fga.check(DEFAULT_STORE_ID, request).get();
 
         // Then
-        verify(mockConfiguration).getApiUrl();
         verify(mockConfiguration).getReadTimeout();
         mockHttpClient.verify().post(postPath).withBody(is(expectedBody)).called(1);
         assertNotNull(response.getData());


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Introduces [OpenTelemetry](https://opentelemetry.io/) metrics reporting into the SDK for specific actions. We're intentionally starting with only a few metric events that we can then grow over time.

We don't have any formal documentation for this currently. We'll write this as we roll it out across all SDKs, so here is a summary of the events and the associated attributes:

| Metric Name                     | Type      | Description                                                                     |
|---------------------------------|-----------|---------------------------------------------------------------------------------|
| `fga-client.request.duration`   | Histogram | The total request time for FGA requests                                         |
| `fga-client.query.duration`     | Histogram | The amount of time the FGA server took to process the request                   |
|` fga-client.credentials.request`| Counter   | The total number of times a new token was requested when using ClientCredentials|


| Attribute Name                 |  Type     | Description                                                                         |
|--------------------------------|----------|-------------------------------------------------------------------------------------|
| `fga-client.response.model_id` | `string` | The authorization model ID that the FGA server used                                 |
| `fga-client.request.method`    | `string` | The FGA method/action that was performed                                            |
| `fga-client.request.store_id`  | `string` | The store ID that was sent as part of the request                                   |
| `fga-client.request.model_id` | `string` | The authorization model ID that was sent as part of the request, if any                    |
| `fga-client.request.client_id` | `string` | The client ID associated with the request, if any  |
| `fga-client.user`              | `string` | The user that is associated with the action of the request for check and list users |
| `http.status_code `            | `int`    | The status code of the response                                                     |
| `http.method`                  | `string` | The HTTP method for the request                                                     |
| `http.host`                    | `string` | Host identifier of the origin the request was sent to                               |

We're implementing this using `opentelemetry-api,` which means that all actions will be a no-op unless an `opentelemetry-sdk` (or equivalent) instance is configured within an application. This is currently in draft as we work through the implementation across SDKs, but we're looking for any feedback folks may have!

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Closes #92 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
