### PR TITLE
fix(OpenTelemetry): `http.request.method` should be enabled by default

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/configuration/TelemetryConfiguration.java
+++ b/src/main/java/dev/openfga/sdk/api/configuration/TelemetryConfiguration.java
@@ -20,6 +20,7 @@ public class TelemetryConfiguration {
         defaultAttributes.put(Attributes.FGA_CLIENT_REQUEST_STORE_ID, Optional.empty());
         defaultAttributes.put(Attributes.FGA_CLIENT_RESPONSE_MODEL_ID, Optional.empty());
         defaultAttributes.put(Attributes.HTTP_HOST, Optional.empty());
+        defaultAttributes.put(Attributes.HTTP_REQUEST_METHOD, Optional.empty());
         defaultAttributes.put(Attributes.HTTP_REQUEST_RESEND_COUNT, Optional.empty());
         defaultAttributes.put(Attributes.HTTP_RESPONSE_STATUS_CODE, Optional.empty());
         defaultAttributes.put(Attributes.URL_FULL, Optional.empty());


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Fix for `http.request.method` not being enabled by default as it should have been.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
