### PR TITLE
docs: remove unsupported attributes from docs

### DIFF
--- a/docs/OpenTelemetry.md
+++ b/docs/OpenTelemetry.md
@@ -26,12 +26,10 @@ In cases when metrics events are sent, they will not be viewable outside of infr
 | `fga-client.request.store_id`  | string | Yes                | Store ID that was sent as part of the request                                     |
 | `fga-client.response.model_id` | string | Yes                | Authorization model ID that the FGA server used                                   |
 | `fga-client.user`              | string | No                 | User associated with the action of the request for check and list users           |
-| `http.client.request.duration` | int    | No                 | Duration for the SDK to complete the request, in milliseconds                     |
-| `http.host`                    | string | Yes                | Host identifier of the origin the request was sent to                              |
+| `http.host`                    | string | Yes                | Host identifier of the origin the request was sent to                             |
 | `http.request.method`          | string | Yes                | HTTP method for the request                                                       |
 | `http.request.resend_count`    | int    | Yes                | Number of retries attempted, if any                                               |
 | `http.response.status_code`    | int    | Yes                | Status code of the response (e.g., `200` for success)                             |
-| `http.server.request.duration` | int    | No                 | Time taken by the FGA server to process and evaluate the request, in milliseconds |
 | `url.scheme`                   | string | Yes                | HTTP scheme of the request (`http`/`https`)                                       |
 | `url.full`                     | string | Yes                | Full URL of the request                                                           |
 | `user_agent.original`          | string | Yes                | User Agent used in the query                                                      |
@@ -79,7 +77,7 @@ public class Example {
                 .put(ServiceAttributes.SERVICE_NAME, "example-app")
                 .put(ServiceAttributes.SERVICE_VERSION, "0.1.0")
                 .build();
-
+    
         SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder()
             .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder().build()).build())
             .setResource(resource)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

The `http.client.request.duration` and `http.server.request.duration` attributes are not supported by the Java SDK. Removing them from the documentation.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

