### PR TITLE
fix: use http1.1 by default

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/client/ApiClient.java
+++ b/src/main/java/dev/openfga/sdk/api/client/ApiClient.java
@@ -75,6 +75,24 @@ public class ApiClient {
      * {@link HttpClient.Builder} here.
      *
      * @param builder Http client builder.
+     */
+    public ApiClient(HttpClient.Builder builder) {
+        this.builder = builder;
+        this.mapper = createDefaultObjectMapper();
+        this.client = this.builder.build();
+        interceptor = null;
+        responseInterceptor = null;
+        asyncResponseInterceptor = null;
+    }
+
+    /**
+     * Create an instance of ApiClient.
+     * <p>
+     * In other contexts, note that any settings in a {@link Configuration}
+     * will take precedence over equivalent settings in the
+     * {@link HttpClient.Builder} here.
+     *
+     * @param builder Http client builder.
      * @param mapper Object mapper.
      */
     public ApiClient(HttpClient.Builder builder, ObjectMapper mapper) {
@@ -177,7 +195,7 @@ public class ApiClient {
     }
 
     protected HttpClient.Builder createDefaultHttpClientBuilder() {
-        return HttpClient.newBuilder();
+        return HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1);
     }
 
     /**

--- a/src/test/java/dev/openfga/sdk/api/client/ApiClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/ApiClientTest.java
@@ -16,6 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.net.http.HttpClient;
+
+import org.checkerframework.checker.units.qual.A;
 import org.junit.jupiter.api.Test;
 
 class ApiClientTest {
@@ -34,5 +36,11 @@ class ApiClientTest {
         apiClient.setHttpClientBuilder(HttpClient.newBuilder());
 
         assertNotEquals(client1, apiClient.getHttpClient());
+    }
+
+    @Test
+    public void httpClientShouldUseHttp1ByDefault() {
+        ApiClient apiClient = new ApiClient();
+        assertEquals(apiClient.getHttpClient().version(), HttpClient.Version.HTTP_1_1);
     }
 }

--- a/src/test/java/dev/openfga/sdk/api/client/ApiClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/ApiClientTest.java
@@ -16,8 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.net.http.HttpClient;
-
-import org.checkerframework.checker.units.qual.A;
 import org.junit.jupiter.api.Test;
 
 class ApiClientTest {
@@ -42,5 +40,13 @@ class ApiClientTest {
     public void httpClientShouldUseHttp1ByDefault() {
         ApiClient apiClient = new ApiClient();
         assertEquals(apiClient.getHttpClient().version(), HttpClient.Version.HTTP_1_1);
+    }
+
+    @Test
+    public void customHttpClientWithHttp2() {
+        HttpClient.Builder builder = HttpClient.newBuilder().version(HttpClient.Version.HTTP_2);
+        ApiClient apiClient = new ApiClient(builder);
+        ;
+        assertEquals(apiClient.getHttpClient().version(), HttpClient.Version.HTTP_2);
     }
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Use HTTP 1.1 by default

## Description
<!-- Provide a detailed description of the changes -->

Configures the default `HttpClient` to use HTTP 1.1 by default.

There are issues observed using HTTP 2 with FGA, as observed in #126 and failures related to receiving GOAWAY frames.

This change updates the default configuration to use HTTP 1.1.

It also includes a new constructor for `ApiClient`, to enable easier configuration for a custom `HttpClient`. If customers wish to use HTTP 2, with this change they can configure the SDK like the following:

```java
// HttpClient.Builder configured for HTTP 2.0
HttpClient.Builder httpBuilder = HttpClient.newBuilder().version(HttpClient.Version.HTTP_2);

final var apiClient = new ApiClient(httpBuilder);

var fgaClient = new OpenFgaClient(configuration, apiClient);
```
## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

#126 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

