### PR TITLE
chore: Migrate CI to sonatype central portal

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -23,13 +23,13 @@ jobs:
         run: ./gradlew build
 
       - name: Run FOSSA scan and upload build data
-        uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac # v1.7.0
+        uses: fossas/fossa-action@c0a7d013f84c8ee5e910593186598625513cc1e4 # v1.6.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           branch: ${{ github.ref_name }}
 
       - name: Run FOSSA tests
-        uses: fossas/fossa-action@3ebcea1862c6ffbd5cf1b4d0bd6b3fe7bd6f2cac # v1.7.0
+        uses: fossas/fossa-action@c0a7d013f84c8ee5e910593186598625513cc1e4 # v1.6.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
           run-tests: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,7 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
 
       - name: Test and Build with Gradle
         run: |
@@ -34,7 +34,7 @@ jobs:
 
       - if: matrix.java == 11
         name: Upload coverage to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
         continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -59,10 +59,10 @@ jobs:
           distribution: "temurin"
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
+        uses: gradle/actions/wrapper-validation@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
 
         # Tasks created by https://github.com/gradle-nexus/publish-plugin
       - name: Publish package
@@ -92,10 +92,10 @@ jobs:
           distribution: "temurin"
 
       - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
+        uses: gradle/actions/wrapper-validation@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
 
       # Tasks created by https://docs.gradle.org/current/userguide/publishing_maven.html
       - name: Publish package

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ public class Example {
 }
 ```
 
-#### Auth0 Client Credentials
+#### Client Credentials
 
 ```java
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -604,6 +604,8 @@ var response = fgaClient.check(request, options).get();
 Similar to [check](#check), but instead of checking a single user-object relationship, accepts a list of relationships to check. Requires OpenFGA version 1.8.0 or greater.
 
 [API Documentation](https://openfga.dev/api/service#/Relationship%20Queries/BatchCheck)
+
+> **Note**: The order of `batchCheck` results is not guaranteed to match the order of the checks provided. Use `correlationId` to pair responses with requests.
 
 > Passing `ClientBatchCheckOptions` is optional. All fields of `ClientBatchCheckOptions` are optional.
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     // Quality
     id 'jacoco'
     id 'jvm-test-suite'
-    id 'com.diffplug.spotless' version '7.0.4'
+    id 'com.diffplug.spotless' version '7.0.3'
 
     // IDE
     id 'idea'
@@ -65,7 +65,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "org.openapitools:jackson-databind-nullable:0.2.6"
-    implementation platform("io.opentelemetry:opentelemetry-bom:1.50.0")
+    implementation platform("io.opentelemetry:opentelemetry-bom:1.49.0")
     implementation "io.opentelemetry:opentelemetry-api"
 }
 
@@ -75,8 +75,8 @@ testing {
             useJUnitJupiter()
             dependencies {
                 implementation 'org.assertj:assertj-core:3.27.3'
-                implementation 'org.mockito:mockito-core:5.18.0'
-                implementation 'org.junit.jupiter:junit-jupiter:5.13.0'
+                implementation 'org.mockito:mockito-core:5.17.0'
+                implementation 'org.junit.jupiter:junit-jupiter:5.12.2'
                 implementation 'org.wiremock:wiremock:3.13.0'
 
                 runtimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -106,8 +106,8 @@ testing {
             dependencies {
                 implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
                 implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-                implementation "org.testcontainers:junit-jupiter:1.21.1"
-                implementation "org.testcontainers:openfga:1.21.1"
+                implementation "org.testcontainers:junit-jupiter:1.21.0"
+                implementation "org.testcontainers:openfga:1.21.0"
                 implementation project()
             }
 

--- a/example/example1/build.gradle
+++ b/example/example1/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'application'
-    id 'com.diffplug.spotless' version '7.0.4'
-    id 'org.jetbrains.kotlin.jvm' version '2.1.21'
+    id 'com.diffplug.spotless' version '7.0.3'
+    id 'org.jetbrains.kotlin.jvm' version '2.1.20'
 }
 
 application {

--- a/publish.gradle
+++ b/publish.gradle
@@ -51,8 +51,8 @@ signing {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri('https://s01.oss.sonatype.org/service/local/'))
-            snapshotRepositoryUrl.set(uri('https://s01.oss.sonatype.org/content/repositories/snapshots/'))
+            nexusUrl.set(uri('https://ossrh-staging-api.central.sonatype.com/service/local/'))
+            snapshotRepositoryUrl.set(uri('https://central.sonatype.com/repository/maven-snapshots/'))
             username.set(System.getenv('MAVEN_USERNAME'))
             password.set(System.getenv('MAVEN_PASSWORD'))
         }

--- a/src/main/java/dev/openfga/sdk/api/OpenFgaApi.java
+++ b/src/main/java/dev/openfga/sdk/api/OpenFgaApi.java
@@ -1154,6 +1154,11 @@ public class OpenFgaApi {
             if (body instanceof BatchCheckRequest) {
                 BatchCheckRequest batchCheckRequest = (BatchCheckRequest) body;
 
+                if (!isNullOrWhitespace(batchCheckRequest.getAuthorizationModelId())) {
+                    telemetryAttributes.put(
+                            Attributes.FGA_CLIENT_REQUEST_MODEL_ID, batchCheckRequest.getAuthorizationModelId());
+                }
+
                 if (batchCheckRequest.getChecks() != null) {
                     telemetryAttributes.put(
                             Attributes.FGA_CLIENT_REQUEST_BATCH_CHECK_SIZE,

--- a/src/main/java/dev/openfga/sdk/api/model/AbstractOpenApiSchema.java
+++ b/src/main/java/dev/openfga/sdk/api/model/AbstractOpenApiSchema.java
@@ -137,8 +137,7 @@ public abstract class AbstractOpenApiSchema {
     public Boolean isNullable() {
         if (Boolean.TRUE.equals(isNullable)) {
             return Boolean.TRUE;
-        } else {
-            return Boolean.FALSE;
         }
+        return Boolean.FALSE;
     }
 }


### PR DESCRIPTION
## Description
Migration of java sdk publishing from OSSRH to Sonatype Central Portal.

Sonatype has announced that the legacy OSSRH service ([oss.sonatype.org](http://oss.sonatype.org/)) will reach end-of-life in June 2025. The openfga/java-sdk currently publishes to Maven Central via OSSRH. To avoid disruptions, we need to migrate publishing to the Central Portal ([central.sonatype.com](http://central.sonatype.com/)).


## References
https://github.com/openfga/sdk-generator/pull/562

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

