### PR TITLE
Fix connectTimeout configuration usage

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/OpenFgaApi.java
+++ b/src/main/java/dev/openfga/sdk/api/OpenFgaApi.java
@@ -90,6 +90,11 @@ public class OpenFgaApi {
         if (defaultHeaders != null) {
             apiClient.addRequestInterceptor(httpRequest -> defaultHeaders.forEach(httpRequest::setHeader));
         }
+
+        Duration connectTimeout = configuration.getConnectTimeout();
+        if (connectTimeout != null) {
+            apiClient.setHttpClientBuilder(apiClient.getHttpClientBuilder().connectTimeout(connectTimeout));
+        }
     }
 
     /**

--- a/src/main/java/dev/openfga/sdk/api/auth/OAuth2Client.java
+++ b/src/main/java/dev/openfga/sdk/api/auth/OAuth2Client.java
@@ -49,6 +49,7 @@ public class OAuth2Client {
         this.authRequest.setScope(clientCredentials.getScopes());
         this.config = new Configuration()
                 .apiUrl(buildApiTokenIssuer(clientCredentials.getApiTokenIssuer()))
+                .connectTimeout(configuration.getConnectTimeout())
                 .maxRetries(configuration.getMaxRetries())
                 .minimumRetryDelay(configuration.getMinimumRetryDelay())
                 .telemetryConfiguration(configuration.getTelemetryConfiguration());


### PR DESCRIPTION
## Summary
- propagate `connectTimeout` from `Configuration` to `ApiClient` builder
- forward the setting through `OAuth2Client`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68767c176db88322b80f8d3ec423d404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring connection timeout for the API client and OAuth2 client, allowing users to set custom connection timeouts for improved control over network behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->