### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Test and Build OpenFGA
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/java-sdk/security/code-scanning/3](https://github.com/openfga/java-sdk/security/code-scanning/3)

To fix the problem, add a `permissions` block to the `test` job in `.github/workflows/main.yaml` to explicitly restrict the permissions granted to the GITHUB_TOKEN. The minimal required permission for this job is likely `contents: read`, as it only needs to check out code and run tests. This change should be made directly under the `test:` job definition, before the `steps:` block. No additional imports or definitions are needed, as this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
