### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -5,6 +5,8 @@ on:
       - main
 jobs:
   semgrep:
+    permissions:
+      contents: read
     name: Scan
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/java-sdk/security/code-scanning/1](https://github.com/openfga/java-sdk/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. In this case, since the job only checks out code and runs Semgrep, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the job level (under `semgrep:`), which will ensure that the job cannot perform any write actions on the repository. This change should be made directly under the `semgrep:` job definition, before the `name:` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to adjust repository access permissions for automated code scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->