### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,4 +1,6 @@
 name: FOSSA
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/java-sdk/security/code-scanning/2](https://github.com/openfga/java-sdk/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN to the minimum required. In this case, the workflow only needs to read repository contents (for actions/checkout and FOSSA scans), so setting `contents: read` is sufficient. The best way to do this is to add the following block at the root level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
