### PR TITLE
chore(ci): allow release workflow write permissions to create the release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -112,6 +112,9 @@ jobs:
     needs: [publish-maven-central, publish-github-packages]
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/java-sdk/security/code-scanning/4](https://github.com/openfga/java-sdk/security/code-scanning/4)

To fix the problem, add a `permissions` block to the `create-release` job in `.github/workflows/main.yaml`. This block should grant only the minimum permissions required for the job to function. Since the job is creating a release using the `GITHUB_TOKEN`, it needs `contents: write` permission (as creating releases requires write access to repository contents). The block should be added at the same indentation level as `steps` and other job-level keys, directly under the `runs-on` line (or after `needs`/`if` if present). No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
