### PR TITLE
chore: use jackson bom and update dependabot ignores

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,8 +7,10 @@ updates:
     schedule:
       interval: "monthly"
     ignore:
-      - dependency-name: "com.diffplug.spotless:spotless-plugin-gradle"
+      - dependency-name: "com.diffplug.spotless"
         versions: [">=8.0.0"]
+      - dependency-name: "org.junit.jupiter:junit-jupiter"
+        versions: [ ">=6.0.0" ]
     groups:
       dependencies:
         patterns:
@@ -19,8 +21,10 @@ updates:
     schedule:
       interval: "monthly"
     ignore:
-      - dependency-name: "com.diffplug.spotless:spotless-plugin-gradle"
+      - dependency-name: "com.diffplug.spotless"
         versions: [">=8.0.0"]
+      - dependency-name: "org.junit.jupiter:junit-jupiter"
+        versions: [ ">=6.0.0" ]
     groups:
       dependencies:
         patterns:
@@ -31,8 +35,10 @@ updates:
     schedule:
       interval: "monthly"
     ignore:
-      - dependency-name: "com.diffplug.spotless:spotless-plugin-gradle"
+      - dependency-name: "com.diffplug.spotless"
         versions: [">=8.0.0"]
+      - dependency-name: "org.junit.jupiter:junit-jupiter"
+        versions: [ ">=6.0.0" ]
     groups:
       dependencies:
         patterns:

--- a/build.gradle
+++ b/build.gradle
@@ -60,11 +60,16 @@ ext {
 
 dependencies {
     implementation "com.google.code.findbugs:jsr305:3.0.2"
-    implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
+
+    // ---- Jackson ----
+    implementation platform("com.fasterxml.jackson:jackson-bom:$jackson_version")
+    implementation "com.fasterxml.jackson.core:jackson-core"
+    implementation "com.fasterxml.jackson.core:jackson-annotations"
+    implementation "com.fasterxml.jackson.core:jackson-databind"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation "org.openapitools:jackson-databind-nullable:0.2.7"
+
+    // ---- OpenTelemetry ----
     implementation platform("io.opentelemetry:opentelemetry-bom:1.53.0")
     implementation "io.opentelemetry:opentelemetry-api"
 }
@@ -104,8 +109,11 @@ testing {
             useJUnitJupiter()
 
             dependencies {
-                implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
-                implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
+                // --- Jackson ---
+                implementation platform("com.fasterxml.jackson:jackson-bom:$jackson_version")
+                implementation "com.fasterxml.jackson.core:jackson-core"
+                implementation "com.fasterxml.jackson.core:jackson-databind"
+
                 implementation "org.testcontainers:junit-jupiter:1.21.3"
                 implementation "org.testcontainers:openfga:1.21.3"
                 implementation project()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Fix up build and dependabot ignores to enable dependabot version bumps

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

Dependabot PRs are failing due to:
- Attempting to update dependencies to new major versions that require java 17 (junit 6, spotless plugin v8)
- Updating Jackson dependency version, and annotations dependency has different version schematics

#### How is it being solved?

- Update `dependabot.yaml` ignores
- Use Jackson BOM 

#### What changes are made to solve it?

See above or the file diffs. Using the jackson bom will allow it to resolve without needing to specify versions for each or having issues if their versioning scheme changes.

## References

https://github.com/openfga/java-sdk/pull/230

<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated dependency management to use centralized BOMs, improving consistency across Jackson and OpenTelemetry libraries.
  - Refined automated dependency update settings to better align with project requirements and reduce unnecessary updates.
  - Applied the same configuration improvements across the main project and example modules.
- Notes
  - No user-facing feature changes.
  - Expect improved build stability and more predictable dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->