### PR TITLE
chore: make streamed list objects client layer public

### DIFF
--- a/examples/streamed-list-objects/README.md
+++ b/examples/streamed-list-objects/README.md
@@ -1,8 +1,5 @@
 # Streamed List Objects Example
 
-> **NOTE:** This example is temporarily disabled as the `streamedListObjects` API is not yet available for public use. It will be enabled in a future release.
-
-<!--
 Demonstrates using `StreamedListObjects` to retrieve objects via the streaming API in the Java SDK.
 
 ## What is StreamedListObjects?

--- a/examples/streamed-list-objects/src/main/java/dev/openfga/sdk/example/StreamedListObjectsExample.java
+++ b/examples/streamed-list-objects/src/main/java/dev/openfga/sdk/example/StreamedListObjectsExample.java
@@ -1,7 +1,3 @@
-// NOTE: This example is temporarily commented out as the streamedListObjects API is not yet available for public use.
-// It will be enabled in a future release.
-
-/*
 package dev.openfga.sdk.example;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -196,4 +192,3 @@ public class StreamedListObjectsExample {
         }
     }
 }
-*/

--- a/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
+++ b/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
@@ -1131,7 +1131,7 @@ public class OpenFgaClient {
      * @return CompletableFuture<Void> that completes when streaming finishes
      * @throws FgaInvalidParameterException When the Store ID is null, empty, or whitespace, or consumer is null
      */
-    CompletableFuture<Void> streamedListObjects(
+    public CompletableFuture<Void> streamedListObjects(
             ClientListObjectsRequest request, Consumer<StreamedListObjectsResponse> consumer)
             throws FgaInvalidParameterException {
         if (consumer == null) {
@@ -1171,7 +1171,7 @@ public class OpenFgaClient {
      * @return CompletableFuture<Void> that completes when streaming finishes
      * @throws FgaInvalidParameterException When the Store ID is null, empty, or whitespace, or consumer is null
      */
-    CompletableFuture<Void> streamedListObjects(
+    public CompletableFuture<Void> streamedListObjects(
             ClientListObjectsRequest request,
             ClientStreamedListObjectsOptions options,
             Consumer<StreamedListObjectsResponse> consumer)
@@ -1211,7 +1211,7 @@ public class OpenFgaClient {
      * @return CompletableFuture<Void> that completes when streaming finishes or exceptionally on error
      * @throws FgaInvalidParameterException When the Store ID is null, empty, or whitespace, or consumer is null
      */
-    CompletableFuture<Void> streamedListObjects(
+    public CompletableFuture<Void> streamedListObjects(
             ClientListObjectsRequest request,
             ClientStreamedListObjectsOptions options,
             Consumer<StreamedListObjectsResponse> consumer,

--- a/src/test-integration/java/dev/openfga/sdk/api/client/OpenFgaClientIntegrationTest.java
+++ b/src/test-integration/java/dev/openfga/sdk/api/client/OpenFgaClientIntegrationTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -375,7 +374,6 @@ public class OpenFgaClientIntegrationTest {
     }
 
     @Test
-    @Disabled("streamedListObjects is private for now")
     public void streamedListObjects() throws Exception {
         // Given - Create a single store for all streaming tests
         String storeId = createStore(thisTestName());

--- a/src/test/java/dev/openfga/sdk/api/client/StreamedListObjectsTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/StreamedListObjectsTest.java
@@ -24,11 +24,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Tests for streaming list objects functionality with CompletableFuture. */
-@Disabled("streamedListObjects is private for now")
 public class StreamedListObjectsTest {
     private static final String DEFAULT_STORE_ID = "01YCP46JKYM8FJCQ37NMBYHE5X";
     private static final String DEFAULT_AUTH_MODEL_ID = "01G5JAVJ41T49E9TT3SKVS7X1J";


### PR DESCRIPTION
Makes streamed list objects client layer available for use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamed list objects API is now publicly available, allowing clients to retrieve objects using streaming responses

* **Documentation**
  * Re-enabled official examples and documentation guides for the streamed list objects functionality

* **Tests**
  * Activated integration and unit tests for the streamed list objects feature

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->