### PR TITLE
chore: Add Java 25 to CI build matrix with conditional Spotless skip

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Test and Build with Gradle
         run: |
           if [ "${{ matrix.java }}" = "25" ]; then
-            ./gradlew build test-integration -x spotlessCheck -x spotlessJavaCheck
+            ./gradlew build test-integration -x spotlessCheck
           else
             ./gradlew build test-integration
           fi


### PR DESCRIPTION
Add Java 25 support to CI test matrix

This PR adds Java 25 (LTS) to the CI build matrix to ensure compatibility with the latest Java LTS release.

**Changes:**
- Added Java 25 to the test matrix alongside Java 17 and 21
- Configured CI to skip Spotless checks when running on Java 25 due to current limitations in Palantir Java Format's Java 25 support
- Java 25 builds will still run all tests and compile checks, only code formatting validation is skipped

This allows us to validate that the SDK builds and runs correctly on Java 25 while we wait for tooling support to catch up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to include Java 25 in the test matrix alongside existing Java versions.
  * Modified build steps to adapt compatibility checks for Java 25 while maintaining full validation for other versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->