### PR TITLE
chore: remove spotless check override for Java 25

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,12 +34,7 @@ jobs:
         uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5.0.1
 
       - name: Test and Build with Gradle
-        run: |
-          if [ "${{ matrix.java }}" = "25" ]; then
-            ./gradlew build test-integration -x spotlessCheck
-          else
-            ./gradlew build test-integration
-          fi
+        run: ./gradlew build test-integration
 
       - if: matrix.java == 17
         name: Upload coverage to Codecov


### PR DESCRIPTION
Removes the spotless check override for Java 25 in the CI workflow. Previously, Java 25 builds were skipping `spotlessCheck` and only running `build test-integration`. This change ensures all Java versions (17, 21, 25) run the full build process consistently, including code formatting checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the build and test pipeline by consolidating the integration workflow, removing version-specific conditional logic for more consistent and streamlined execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->