### PR TITLE
fix: share single Telemetry instance per SDK client

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/OpenFgaApi.java
+++ b/src/main/java/dev/openfga/sdk/api/OpenFgaApi.java
@@ -77,9 +77,14 @@ public class OpenFgaApi {
     }
 
     public OpenFgaApi(Configuration configuration, ApiClient apiClient) throws FgaInvalidParameterException {
+        this(configuration, apiClient, new Telemetry(configuration));
+    }
+
+    public OpenFgaApi(Configuration configuration, ApiClient apiClient, Telemetry telemetry)
+            throws FgaInvalidParameterException {
         this.apiClient = apiClient;
         this.configuration = configuration;
-        this.telemetry = new Telemetry(this.configuration);
+        this.telemetry = telemetry;
 
         if (configuration.getCredentials().getCredentialsMethod() == CredentialsMethod.CLIENT_CREDENTIALS) {
             this.oAuth2Client = new OAuth2Client(configuration, apiClient);
@@ -146,7 +151,8 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("POST", path, body, configuration);
-            return new HttpRequestAttempt<>(request, "batchCheck", BatchCheckResponse.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(
+                            request, "batchCheck", BatchCheckResponse.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -202,7 +208,7 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("POST", path, body, configuration);
-            return new HttpRequestAttempt<>(request, "check", CheckResponse.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(request, "check", CheckResponse.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -252,7 +258,8 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("POST", path, body, configuration);
-            return new HttpRequestAttempt<>(request, "createStore", CreateStoreResponse.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(
+                            request, "createStore", CreateStoreResponse.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -301,7 +308,7 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("DELETE", path, configuration);
-            return new HttpRequestAttempt<>(request, "deleteStore", Void.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(request, "deleteStore", Void.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -357,7 +364,8 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("POST", path, body, configuration);
-            return new HttpRequestAttempt<>(request, "expand", ExpandResponse.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(
+                            request, "expand", ExpandResponse.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -407,7 +415,8 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("GET", path, configuration);
-            return new HttpRequestAttempt<>(request, "getStore", GetStoreResponse.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(
+                            request, "getStore", GetStoreResponse.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -463,7 +472,8 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("POST", path, body, configuration);
-            return new HttpRequestAttempt<>(request, "listObjects", ListObjectsResponse.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(
+                            request, "listObjects", ListObjectsResponse.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -516,7 +526,8 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("GET", path, configuration);
-            return new HttpRequestAttempt<>(request, "listStores", ListStoresResponse.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(
+                            request, "listStores", ListStoresResponse.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -572,7 +583,8 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("POST", path, body, configuration);
-            return new HttpRequestAttempt<>(request, "listUsers", ListUsersResponse.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(
+                            request, "listUsers", ListUsersResponse.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -628,7 +640,7 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("POST", path, body, configuration);
-            return new HttpRequestAttempt<>(request, "read", ReadResponse.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(request, "read", ReadResponse.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -687,7 +699,12 @@ public class OpenFgaApi {
         try {
             HttpRequest request = buildHttpRequest("GET", path, configuration);
             return new HttpRequestAttempt<>(
-                            request, "readAssertions", ReadAssertionsResponse.class, apiClient, configuration)
+                            request,
+                            "readAssertions",
+                            ReadAssertionsResponse.class,
+                            apiClient,
+                            configuration,
+                            telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -749,7 +766,8 @@ public class OpenFgaApi {
                             "readAuthorizationModel",
                             ReadAuthorizationModelResponse.class,
                             apiClient,
-                            configuration)
+                            configuration,
+                            telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -813,7 +831,8 @@ public class OpenFgaApi {
                             "readAuthorizationModels",
                             ReadAuthorizationModelsResponse.class,
                             apiClient,
-                            configuration)
+                            configuration,
+                            telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -899,7 +918,8 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("GET", path, configuration);
-            return new HttpRequestAttempt<>(request, "readChanges", ReadChangesResponse.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(
+                            request, "readChanges", ReadChangesResponse.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -961,7 +981,8 @@ public class OpenFgaApi {
                             "streamedListObjects",
                             StreamResultOfStreamedListObjectsResponse.class,
                             apiClient,
-                            configuration)
+                            configuration,
+                            telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -1016,7 +1037,7 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("POST", path, body, configuration);
-            return new HttpRequestAttempt<>(request, "write", Object.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(request, "write", Object.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -1083,7 +1104,7 @@ public class OpenFgaApi {
 
         try {
             HttpRequest request = buildHttpRequest("PUT", path, body, configuration);
-            return new HttpRequestAttempt<>(request, "writeAssertions", Void.class, apiClient, configuration)
+            return new HttpRequestAttempt<>(request, "writeAssertions", Void.class, apiClient, configuration, telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {
@@ -1145,7 +1166,8 @@ public class OpenFgaApi {
                             "writeAuthorizationModel",
                             WriteAuthorizationModelResponse.class,
                             apiClient,
-                            configuration)
+                            configuration,
+                            telemetry)
                     .addTelemetryAttributes(telemetryAttributes)
                     .attemptHttpRequest();
         } catch (ApiException e) {

--- a/src/main/java/dev/openfga/sdk/api/auth/OAuth2Client.java
+++ b/src/main/java/dev/openfga/sdk/api/auth/OAuth2Client.java
@@ -78,7 +78,8 @@ public class OAuth2Client {
                 ApiClient.formRequestBuilder("POST", "", this.authRequest.buildFormRequestBody(), config);
         HttpRequest request = requestBuilder.build();
 
-        return new HttpRequestAttempt<>(request, "exchangeToken", CredentialsFlowResponse.class, apiClient, config)
+        return new HttpRequestAttempt<>(
+                        request, "exchangeToken", CredentialsFlowResponse.class, apiClient, config, telemetry)
                 .attemptHttpRequest()
                 .thenApply(ApiResponse::getData);
     }

--- a/src/main/java/dev/openfga/sdk/api/client/ApiExecutor.java
+++ b/src/main/java/dev/openfga/sdk/api/client/ApiExecutor.java
@@ -3,6 +3,7 @@ package dev.openfga.sdk.api.client;
 import dev.openfga.sdk.api.configuration.Configuration;
 import dev.openfga.sdk.errors.ApiException;
 import dev.openfga.sdk.errors.FgaInvalidParameterException;
+import dev.openfga.sdk.telemetry.Telemetry;
 import java.io.IOException;
 import java.net.http.HttpRequest;
 import java.util.Map;
@@ -29,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 public class ApiExecutor {
     private final ApiClient apiClient;
     private final Configuration configuration;
+    private final Telemetry telemetry;
 
     /**
      * Constructs an ApiExecutor instance. Typically called via {@link OpenFgaClient#apiExecutor()}.
@@ -37,14 +39,29 @@ public class ApiExecutor {
      * @param configuration Client configuration
      */
     public ApiExecutor(ApiClient apiClient, Configuration configuration) {
+        this(apiClient, configuration, new Telemetry(configuration));
+    }
+
+    /**
+     * Constructs an ApiExecutor instance. Typically called via {@link OpenFgaClient#apiExecutor()}.
+     *
+     * @param apiClient API client for HTTP operations
+     * @param configuration Client configuration
+     * @param telemetry Telemetry instance for collecting metrics
+     */
+    public ApiExecutor(ApiClient apiClient, Configuration configuration, Telemetry telemetry) {
         if (apiClient == null) {
             throw new IllegalArgumentException("ApiClient cannot be null");
         }
         if (configuration == null) {
             throw new IllegalArgumentException("Configuration cannot be null");
         }
+        if (telemetry == null) {
+            throw new IllegalArgumentException("Telemetry cannot be null");
+        }
         this.apiClient = apiClient;
         this.configuration = configuration;
+        this.telemetry = telemetry;
     }
 
     /**
@@ -87,7 +104,7 @@ public class ApiExecutor {
 
             String methodName = "apiExecutor:" + requestBuilder.getMethod() + ":" + requestBuilder.getPath();
 
-            return new HttpRequestAttempt<>(httpRequest, methodName, responseType, apiClient, configuration)
+            return new HttpRequestAttempt<>(httpRequest, methodName, responseType, apiClient, configuration, telemetry)
                     .attemptHttpRequest();
 
         } catch (IOException e) {

--- a/src/main/java/dev/openfga/sdk/api/client/HttpRequestAttempt.java
+++ b/src/main/java/dev/openfga/sdk/api/client/HttpRequestAttempt.java
@@ -37,13 +37,27 @@ public class HttpRequestAttempt<T> {
     public HttpRequestAttempt(
             HttpRequest request, String name, Class<T> clazz, ApiClient apiClient, Configuration configuration)
             throws FgaInvalidParameterException {
+        this(request, name, clazz, apiClient, configuration, new Telemetry(configuration));
+    }
+
+    public HttpRequestAttempt(
+            HttpRequest request,
+            String name,
+            Class<T> clazz,
+            ApiClient apiClient,
+            Configuration configuration,
+            Telemetry telemetry)
+            throws FgaInvalidParameterException {
         assertParamExists(configuration.getMaxRetries(), "maxRetries", "Configuration");
+        if (telemetry == null) {
+            throw new IllegalArgumentException("Telemetry cannot be null");
+        }
         this.apiClient = apiClient;
         this.configuration = configuration;
         this.name = name;
         this.request = request;
         this.clazz = clazz;
-        this.telemetry = new Telemetry(configuration);
+        this.telemetry = telemetry;
         this.telemetryAttributes = new HashMap<>();
     }
 

--- a/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
+++ b/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
@@ -9,6 +9,7 @@ import dev.openfga.sdk.api.configuration.*;
 import dev.openfga.sdk.api.model.*;
 import dev.openfga.sdk.constants.FgaConstants;
 import dev.openfga.sdk.errors.*;
+import dev.openfga.sdk.telemetry.Telemetry;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -22,6 +23,7 @@ import java.util.stream.Stream;
 
 public class OpenFgaClient {
     private final ApiClient apiClient;
+    private Telemetry telemetry;
     private ClientConfiguration configuration;
     private OpenFgaApi api;
 
@@ -32,7 +34,8 @@ public class OpenFgaClient {
     public OpenFgaClient(ClientConfiguration configuration, ApiClient apiClient) throws FgaInvalidParameterException {
         this.apiClient = apiClient;
         this.configuration = configuration;
-        this.api = new OpenFgaApi(configuration, apiClient);
+        this.telemetry = new Telemetry(configuration);
+        this.api = new OpenFgaApi(configuration, apiClient, telemetry);
     }
 
     /* ***********
@@ -63,7 +66,7 @@ public class OpenFgaClient {
      * @return ApiExecutor instance
      */
     public ApiExecutor apiExecutor() {
-        return new ApiExecutor(this.apiClient, this.configuration);
+        return new ApiExecutor(this.apiClient, this.configuration, this.telemetry);
     }
 
     public void setStoreId(String storeId) {
@@ -76,7 +79,8 @@ public class OpenFgaClient {
 
     public void setConfiguration(ClientConfiguration configuration) throws FgaInvalidParameterException {
         this.configuration = configuration;
-        this.api = new OpenFgaApi(configuration, apiClient);
+        this.telemetry = new Telemetry(configuration);
+        this.api = new OpenFgaApi(configuration, apiClient, telemetry);
     }
 
     /* ********

--- a/src/main/java/dev/openfga/sdk/telemetry/Metrics.java
+++ b/src/main/java/dev/openfga/sdk/telemetry/Metrics.java
@@ -6,8 +6,8 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The Metrics class provides methods for creating and publishing metrics using OpenTelemetry.
@@ -24,8 +24,8 @@ public class Metrics {
 
     public Metrics(Configuration configuration) {
         this.meter = GlobalOpenTelemetry.get().getMeterProvider().get("openfga-sdk");
-        this.counters = new HashMap<>();
-        this.histograms = new HashMap<>();
+        this.counters = new ConcurrentHashMap<>();
+        this.histograms = new ConcurrentHashMap<>();
         this.configuration = configuration;
         if (this.configuration.getTelemetryConfiguration() == null) {
             this.configuration.telemetryConfiguration(new TelemetryConfiguration());
@@ -55,15 +55,9 @@ public class Metrics {
                 || !configuration.getTelemetryConfiguration().metrics().containsKey(counter)) {
             return null;
         }
-        if (!counters.containsKey(counter.getName())) {
-            counters.put(
-                    counter.getName(),
-                    meter.counterBuilder(counter.getName())
-                            .setDescription(counter.getDescription())
-                            .build());
-        }
-
-        LongCounter counterInstance = counters.get(counter.getName());
+        LongCounter counterInstance = counters.computeIfAbsent(counter.getName(), name -> meter.counterBuilder(name)
+                .setDescription(counter.getDescription())
+                .build());
 
         if (value != null) {
             counterInstance.add(value, Attributes.prepare(attributes, counter, configuration));
@@ -87,16 +81,11 @@ public class Metrics {
             return null;
         }
 
-        if (!histograms.containsKey(histogram.getName())) {
-            histograms.put(
-                    histogram.getName(),
-                    meter.histogramBuilder(histogram.getName())
-                            .setDescription(histogram.getDescription())
-                            .setUnit(histogram.getUnit())
-                            .build());
-        }
-
-        DoubleHistogram histogramInstance = histograms.get(histogram.getName());
+        DoubleHistogram histogramInstance =
+                histograms.computeIfAbsent(histogram.getName(), name -> meter.histogramBuilder(name)
+                        .setDescription(histogram.getDescription())
+                        .setUnit(histogram.getUnit())
+                        .build());
 
         if (value != null) {
             histogramInstance.record(value, Attributes.prepare(attributes, histogram, configuration));

--- a/src/main/java/dev/openfga/sdk/telemetry/Telemetry.java
+++ b/src/main/java/dev/openfga/sdk/telemetry/Telemetry.java
@@ -6,8 +6,8 @@ import dev.openfga.sdk.api.configuration.Configuration;
  * The Telemetry class provides access to telemetry-related functionality.
  */
 public class Telemetry {
-    private Configuration configuration = null;
-    private Metrics metrics = null;
+    private final Configuration configuration;
+    private volatile Metrics metrics;
 
     public Telemetry(Configuration configuration) {
         this.configuration = configuration;
@@ -16,12 +16,19 @@ public class Telemetry {
     /**
      * Returns a Metrics singleton for collecting telemetry data.
      * If the Metrics singleton has not previously been initialized, it will be created.
+     * This method is thread-safe via double-checked locking.
      */
     public Metrics metrics() {
-        if (metrics == null) {
-            metrics = new Metrics(configuration);
+        Metrics result = metrics;
+        if (result == null) {
+            synchronized (this) {
+                result = metrics;
+                if (result == null) {
+                    result = new Metrics(configuration);
+                    metrics = result;
+                }
+            }
         }
-
-        return metrics;
+        return result;
     }
 }

--- a/src/test/java/dev/openfga/sdk/api/client/ApiExecutorTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/ApiExecutorTest.java
@@ -381,4 +381,12 @@ public class ApiExecutorTest {
                 ApiExecutorRequestBuilder.builder(HttpMethod.GET, "/test").build();
         assertThrows(IllegalArgumentException.class, () -> client.apiExecutor().send(request, null));
     }
+
+    @Test
+    public void twoParamConstructor_shouldCreateWithOwnTelemetry() throws Exception {
+        // Verifies the backward-compatible 2-param constructor works
+        ClientConfiguration config = new ClientConfiguration().apiUrl(fgaApiUrl).storeId(DEFAULT_STORE_ID);
+        ApiExecutor executor = new ApiExecutor(new ApiClient(), config);
+        assertNotNull(executor);
+    }
 }

--- a/src/test/java/dev/openfga/sdk/api/client/HttpRequestAttemptRetryTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/HttpRequestAttemptRetryTest.java
@@ -13,6 +13,7 @@ import dev.openfga.sdk.constants.FgaConstants;
 import dev.openfga.sdk.errors.ApiException;
 import dev.openfga.sdk.errors.FgaApiInternalError;
 import dev.openfga.sdk.errors.FgaError;
+import dev.openfga.sdk.telemetry.Telemetry;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 import java.time.Instant;
@@ -26,6 +27,7 @@ class HttpRequestAttemptRetryTest {
     private WireMockServer wireMockServer;
     private ClientConfiguration configuration;
     private ApiClient apiClient;
+    private Telemetry telemetry;
 
     @BeforeEach
     void setUp() {
@@ -39,6 +41,7 @@ class HttpRequestAttemptRetryTest {
                 .minimumRetryDelay(Duration.ofMillis(10)); // Short delay for testing
 
         apiClient = new ApiClient();
+        telemetry = new Telemetry(configuration);
     }
 
     @AfterEach
@@ -73,7 +76,7 @@ class HttpRequestAttemptRetryTest {
                 .build();
 
         HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration);
+                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration, telemetry);
 
         // When
         ApiResponse<Void> response = attempt.attemptHttpRequest().get();
@@ -110,7 +113,7 @@ class HttpRequestAttemptRetryTest {
                 .build();
 
         HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration);
+                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration, telemetry);
 
         // When
         ApiResponse<Void> response = attempt.attemptHttpRequest().get();
@@ -134,7 +137,7 @@ class HttpRequestAttemptRetryTest {
                 .build();
 
         HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration);
+                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration, telemetry);
 
         // When & Then
         ExecutionException exception = assertThrows(
@@ -174,7 +177,7 @@ class HttpRequestAttemptRetryTest {
                 .build();
 
         HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration);
+                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration, telemetry);
 
         // When
         ApiResponse<Void> response = attempt.attemptHttpRequest().get();
@@ -198,7 +201,7 @@ class HttpRequestAttemptRetryTest {
                 .build();
 
         HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration);
+                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration, telemetry);
 
         // When & Then
         ExecutionException exception = assertThrows(
@@ -224,7 +227,7 @@ class HttpRequestAttemptRetryTest {
                 .build();
 
         HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration);
+                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration, telemetry);
 
         // When & Then
         ExecutionException exception = assertThrows(
@@ -260,7 +263,7 @@ class HttpRequestAttemptRetryTest {
                 .build();
 
         HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration);
+                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration, telemetry);
 
         // When
         ApiResponse<Void> response = attempt.attemptHttpRequest().get();
@@ -301,7 +304,7 @@ class HttpRequestAttemptRetryTest {
                 .build();
 
         HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration);
+                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, configuration, telemetry);
 
         // When
         ApiResponse<Void> response = attempt.attemptHttpRequest().get();
@@ -331,8 +334,8 @@ class HttpRequestAttemptRetryTest {
                 .timeout(Duration.ofMillis(50)) // Short timeout to force connection error
                 .build();
 
-        HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, networkConfig);
+        HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(
+                request, "test", Void.class, apiClient, networkConfig, new Telemetry(networkConfig));
 
         Instant startTime = Instant.now();
 
@@ -371,8 +374,8 @@ class HttpRequestAttemptRetryTest {
                 .timeout(Duration.ofMillis(50)) // Short timeout to force connection error quickly
                 .build();
 
-        HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, networkConfig);
+        HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(
+                request, "test", Void.class, apiClient, networkConfig, new Telemetry(networkConfig));
 
         Instant startTime = Instant.now();
 
@@ -408,7 +411,8 @@ class HttpRequestAttemptRetryTest {
                 .timeout(Duration.ofMillis(500)) // Reasonable timeout
                 .build();
 
-        HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(request, "test", Void.class, apiClient, dnsConfig);
+        HttpRequestAttempt<Void> attempt =
+                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, dnsConfig, new Telemetry(dnsConfig));
 
         Instant startTime = Instant.now();
 
@@ -446,7 +450,8 @@ class HttpRequestAttemptRetryTest {
                 .timeout(Duration.ofMillis(1000))
                 .build();
 
-        HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(request, "test", Void.class, apiClient, dnsConfig);
+        HttpRequestAttempt<Void> attempt =
+                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, dnsConfig, new Telemetry(dnsConfig));
 
         // When & Then
         ExecutionException exception = assertThrows(
@@ -506,8 +511,8 @@ class HttpRequestAttemptRetryTest {
                 .maxRetries(2)
                 .minimumRetryDelay(Duration.ofMillis(100)); // Should act as floor for exponential backoff
 
-        HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, globalConfig);
+        HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(
+                request, "test", Void.class, apiClient, globalConfig, new Telemetry(globalConfig));
 
         Instant startTime = Instant.now();
 
@@ -556,8 +561,8 @@ class HttpRequestAttemptRetryTest {
                 .maxRetries(2)
                 .minimumRetryDelay(Duration.ofMillis(150)); // Should NOT override Retry-After
 
-        HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, globalConfig);
+        HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(
+                request, "test", Void.class, apiClient, globalConfig, new Telemetry(globalConfig));
 
         Instant startTime = Instant.now();
 
@@ -604,8 +609,8 @@ class HttpRequestAttemptRetryTest {
                 .maxRetries(2)
                 .minimumRetryDelay(Duration.ofMillis(50)); // Should NOT override Retry-After: 100ms
 
-        HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, globalConfig);
+        HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(
+                request, "test", Void.class, apiClient, globalConfig, new Telemetry(globalConfig));
 
         Instant startTime = Instant.now();
 
@@ -643,8 +648,8 @@ class HttpRequestAttemptRetryTest {
                 configuration.override(new dev.openfga.sdk.api.configuration.ConfigurationOverride()
                         .minimumRetryDelay(Duration.ofMillis(100)));
 
-        HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, overriddenConfig);
+        HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(
+                request, "test", Void.class, apiClient, overriddenConfig, new Telemetry(overriddenConfig));
 
         Instant startTime = Instant.now();
 
@@ -687,8 +692,8 @@ class HttpRequestAttemptRetryTest {
                     .POST(HttpRequest.BodyPublishers.ofString("{}"))
                     .build();
 
-            HttpRequestAttempt<Void> attempt =
-                    new HttpRequestAttempt<>(request, "check", Void.class, apiClient, effectiveConfig);
+            HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(
+                    request, "check", Void.class, apiClient, effectiveConfig, new Telemetry(effectiveConfig));
             attempt.attemptHttpRequest().get();
         });
 
@@ -726,8 +731,8 @@ class HttpRequestAttemptRetryTest {
                 configuration.override(new dev.openfga.sdk.api.configuration.ConfigurationOverride()
                         .minimumRetryDelay(Duration.ofMillis(150)));
 
-        HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, overriddenConfig);
+        HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(
+                request, "test", Void.class, apiClient, overriddenConfig, new Telemetry(overriddenConfig));
 
         Instant startTime = Instant.now();
 
@@ -776,8 +781,8 @@ class HttpRequestAttemptRetryTest {
         // Verify the override took effect
         assertEquals(Duration.ofMillis(500), overriddenConfig.getMinimumRetryDelay());
 
-        HttpRequestAttempt<Void> attempt =
-                new HttpRequestAttempt<>(request, "test", Void.class, apiClient, overriddenConfig);
+        HttpRequestAttempt<Void> attempt = new HttpRequestAttempt<>(
+                request, "test", Void.class, apiClient, overriddenConfig, new Telemetry(overriddenConfig));
 
         Instant startTime = Instant.now();
 

--- a/src/test/java/dev/openfga/sdk/telemetry/TelemetryTest.java
+++ b/src/test/java/dev/openfga/sdk/telemetry/TelemetryTest.java
@@ -3,6 +3,11 @@ package dev.openfga.sdk.telemetry;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.openfga.sdk.api.configuration.Configuration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
 class TelemetryTest {
@@ -17,5 +22,35 @@ class TelemetryTest {
 
         // then
         assertThat(firstCall).isNotNull().isSameAs(secondCall);
+    }
+
+    @Test
+    void shouldReturnSameMetricsInstanceUnderConcurrentAccess() throws InterruptedException {
+        // given
+        Telemetry telemetry = new Telemetry(new Configuration());
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Metrics> results = new CopyOnWriteArrayList<>();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    results.add(telemetry.metrics());
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+        startLatch.countDown();
+        executor.shutdown();
+        executor.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
+
+        // then
+        assertThat(results).hasSize(threadCount);
+        Metrics expected = results.get(0);
+        assertThat(results).allSatisfy(m -> assertThat(m).isSameAs(expected));
     }
 }


### PR DESCRIPTION
## Description

Fixes #209

The SDK was creating new `Telemetry`, `Metrics`, and associated OpenTelemetry instruments for every HTTP request instead of sharing a single instance per SDK client. This caused:
- Wasted object allocation on every request
- Fragmented OTel instrument instances (potential metric aggregation issues)
- Repeated `GlobalOpenTelemetry` meter lookups

Additionally, once a single `Telemetry`/`Metrics` instance is shared across concurrent async requests, the existing code had thread-safety bugs that are fixed here.

## Changes

**Thread safety (`Telemetry.java`, `Metrics.java`):**
- `Telemetry.metrics()`: `volatile` field + double-checked locking for safe lazy init
- `Metrics`: `HashMap` → `ConcurrentHashMap`, check-then-put → `computeIfAbsent()` for counters and histograms

**Shared instance wiring (`OpenFgaClient.java`, `OpenFgaApi.java`, `ApiExecutor.java`, `OAuth2Client.java`, `HttpRequestAttempt.java`):**
- `OpenFgaClient` owns the single `Telemetry` instance, passes it to `OpenFgaApi` and `ApiExecutor`
- `OpenFgaApi` passes shared telemetry through to all `HttpRequestAttempt` calls
- `OAuth2Client` passes its own `Telemetry` (one per client, not per request) to `HttpRequestAttempt`
- New constructors validate `telemetry` parameter for null, consistent with existing parameter validation

**Backward compatibility:**
- All existing public constructors are preserved as overloads that delegate to new versions
- `HttpRequestAttempt(5-param)` delegates to new `HttpRequestAttempt(6-param)`
- `ApiExecutor(2-param)` delegates to new `ApiExecutor(3-param)`
- `OpenFgaApi(1-param)` and `OpenFgaApi(2-param)` preserved, new `OpenFgaApi(3-param)` added
- No breaking changes

## Test plan

- [x] Existing `TelemetryTest.shouldBeASingletonMetricsInitialization` validates singleton behavior
- [x] New concurrent access test verifies `Telemetry.metrics()` returns same instance across 10 threads
- [x] New test for backward-compatible `ApiExecutor` 2-param constructor
- [x] `HttpRequestAttemptRetryTest` updated to use shared telemetry instances
- [x] `./gradlew check` passes (tests + spotless formatting)
- [ ] CI passes on Java 17, 21, 25