### PR TITLE
chore: ignore gradle/actions/setup-gradle v6 in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -48,6 +48,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "gradle/actions/setup-gradle"
+        versions: [">= 6.0.0, < 7.0.0"]
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
gradle/actions/setup-gradle v6 introduced a licensing change that requires acceptance of new Terms of Use tied to a proprietary caching component. The ToS language is broad and legally ambiguous — raising concerns about IP rights over cached build artifacts (e.g. sources.jar).

Key concerns:
- ToS grants Gradle broad rights over "user submissions", unclear scope
- Disabling the new caching also disables Gradle distribution caching (known bug)
- No clear legal guidance for private/commercial repos yet

Gradle maintainers have stated no data is currently sent to Gradle and plan to clarify the ToS, but until that happens we stay on v5 to avoid accidental acceptance of unclear terms.

Ref: https://github.com/gradle/actions/issues/917

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependency management configuration to refine automated update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->