### PR TITLE
fix: promote Jackson dependencies to api scope in published POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java'
+    id 'java-library'
 
     // Quality
     id 'jacoco'
@@ -62,10 +62,10 @@ dependencies {
     implementation "com.google.code.findbugs:jsr305:3.0.2"
 
     // ---- Jackson ----
-    implementation platform("com.fasterxml.jackson:jackson-bom:$jackson_version")
-    implementation "com.fasterxml.jackson.core:jackson-core"
-    implementation "com.fasterxml.jackson.core:jackson-annotations"
-    implementation "com.fasterxml.jackson.core:jackson-databind"
+    api platform("com.fasterxml.jackson:jackson-bom:$jackson_version")
+    api "com.fasterxml.jackson.core:jackson-core"
+    api "com.fasterxml.jackson.core:jackson-annotations"
+    api "com.fasterxml.jackson.core:jackson-databind"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation "org.openapitools:jackson-databind-nullable:0.2.10"
 


### PR DESCRIPTION
## Summary

- Switches the Gradle plugin from `java` to `java-library` to enable the `api` dependency configuration
- Promotes `jackson-core`, `jackson-annotations`, and `jackson-databind` from `implementation` to `api` so they appear as `compile` scope in the published Maven POM
- `jackson-datatype-jsr310` and `jackson-databind-nullable` remain `implementation` as they don't appear in the public API surface

## Why

These Jackson types are used in public model class annotations and `ApiClient` imports. Declaring them as `implementation` maps to `runtime` scope in Maven, meaning downstream Maven consumers don't have them on their compile classpath — causing `unknown enum constant` compiler warnings.

Fixes #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to expose Jackson libraries as part of the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->