### PR TITLE
fix: add transactions and isTransactionsEnabled to ClientWriteOptions

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/configuration/ClientWriteOptions.java
+++ b/src/main/java/dev/openfga/sdk/api/configuration/ClientWriteOptions.java
@@ -59,9 +59,10 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
     /**
      * Sets whether transactions should be used when writing tuples.
      *
-     * <p>When {@code true}, writes are sent as a single transactional request. When {@code false},
-     * writes are split into chunks and sent as individual non-transactional requests, with chunk
-     * size controlled by {@link #transactionChunkSize(int)}.
+     * <p>When {@code true}, all writes and deletes are sent as a single atomic request — if any
+     * tuple fails, the entire operation is rolled back. When {@code false}, tuples are split into
+     * chunks and sent as separate requests, each chunk atomic on its own but with no atomicity
+     * guarantee across the full set. Chunk size is controlled by {@link #transactionChunkSize(int)}.
      *
      * @param enabled {@code true} to enable transactions (default), {@code false} to disable them
      * @return this {@code ClientWriteOptions} instance for method chaining

--- a/src/main/java/dev/openfga/sdk/api/configuration/ClientWriteOptions.java
+++ b/src/main/java/dev/openfga/sdk/api/configuration/ClientWriteOptions.java
@@ -31,11 +31,57 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
         return authorizationModelId;
     }
 
+    /**
+     * Sets whether transactions should be used when writing tuples.
+     *
+     * <p>When {@code true}, writes are sent as a single transactional request. When {@code false},
+     * writes are split into chunks and sent as individual non-transactional requests, with chunk
+     * size controlled by {@link #transactionChunkSize(int)}.
+     *
+     * @param enabled {@code true} to enable transactions (default), {@code false} to disable them
+     * @return this {@code ClientWriteOptions} instance for method chaining
+     * @see #isTransactionsEnabled()
+     */
+    public ClientWriteOptions transactions(boolean enabled) {
+        this.disableTransactions = !enabled;
+        return this;
+    }
+
+    /**
+     * Returns whether transactions are enabled for write operations.
+     *
+     * @return {@code true} if transactions are enabled (default), {@code false} if disabled
+     * @see #transactions(boolean)
+     */
+    public boolean isTransactionsEnabled() {
+        return disableTransactions == null || !disableTransactions;
+    }
+
+    /**
+     * Sets whether transactions should be disabled when writing tuples.
+     *
+     * @param disableTransactions {@code true} to disable transactions, {@code false} to enable them
+     * @return this {@code ClientWriteOptions} instance for method chaining
+     * @deprecated Use {@link #transactions(boolean)} instead. This method will be removed in a
+     *     future release. Replace {@code disableTransactions(true)} with
+     *     {@code transactions(false)}, and {@code disableTransactions(false)} with
+     *     {@code transactions(true)}.
+     */
+    @Deprecated
     public ClientWriteOptions disableTransactions(boolean disableTransactions) {
         this.disableTransactions = disableTransactions;
         return this;
     }
 
+    /**
+     * Returns whether transactions are disabled for write operations.
+     *
+     * @return {@code true} if transactions are disabled, {@code false} if enabled (default)
+     * @deprecated Use {@link #isTransactionsEnabled()} instead. This method will be removed in a
+     *     future release. Note that {@code isTransactionsEnabled()} returns the inverse of
+     *     this method.
+     */
+    @Deprecated
     public boolean disableTransactions() {
         return disableTransactions != null && disableTransactions;
     }

--- a/src/main/java/dev/openfga/sdk/api/configuration/ClientWriteOptions.java
+++ b/src/main/java/dev/openfga/sdk/api/configuration/ClientWriteOptions.java
@@ -88,12 +88,7 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
      *
      * @param disableTransactions {@code true} to disable transactions, {@code false} to enable them
      * @return this {@code ClientWriteOptions} instance for method chaining
-     * @deprecated Use {@link #transactions(boolean)} instead. This method will be removed in a
-     *     future release. Replace {@code disableTransactions(true)} with
-     *     {@code transactions(false)}, and {@code disableTransactions(false)} with
-     *     {@code transactions(true)}.
      */
-    @Deprecated
     public ClientWriteOptions disableTransactions(boolean disableTransactions) {
         this.transactionsEnabled = !disableTransactions;
         return this;
@@ -103,11 +98,7 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
      * Returns whether transactions are disabled for write operations.
      *
      * @return {@code true} if transactions are disabled, {@code false} if enabled (default)
-     * @deprecated Use {@link #isTransactionsEnabled()} instead. This method will be removed in a
-     *     future release. Note that {@code isTransactionsEnabled()} returns the inverse of
-     *     this method.
      */
-    @Deprecated
     public boolean disableTransactions() {
         return !transactionsEnabled;
     }

--- a/src/main/java/dev/openfga/sdk/api/configuration/ClientWriteOptions.java
+++ b/src/main/java/dev/openfga/sdk/api/configuration/ClientWriteOptions.java
@@ -4,14 +4,26 @@ import dev.openfga.sdk.api.model.WriteRequestDeletes;
 import dev.openfga.sdk.api.model.WriteRequestWrites;
 import java.util.Map;
 
+/**
+ * Options for controlling the behavior of write operations on the OpenFGA client.
+ *
+ * <p>Use this class to configure how tuples are written, including whether to use transactions,
+ * how writes are chunked, and how duplicate or missing tuples are handled.
+ */
 public class ClientWriteOptions implements AdditionalHeadersSupplier {
     private Map<String, String> additionalHeaders;
     private String authorizationModelId;
-    private Boolean disableTransactions = false;
+    private boolean transactionsEnabled = true;
     private int transactionChunkSize;
     private WriteRequestWrites.OnDuplicateEnum onDuplicate;
     private WriteRequestDeletes.OnMissingEnum onMissing;
 
+    /**
+     * Sets additional HTTP headers to include in write requests.
+     *
+     * @param additionalHeaders a map of header names to values
+     * @return this {@code ClientWriteOptions} instance for method chaining
+     */
     public ClientWriteOptions additionalHeaders(Map<String, String> additionalHeaders) {
         this.additionalHeaders = additionalHeaders;
         return this;
@@ -22,11 +34,24 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
         return this.additionalHeaders;
     }
 
+    /**
+     * Sets the authorization model ID to use for write operations.
+     *
+     * <p>If not set, the client will use the authorization model ID from its configuration.
+     *
+     * @param authorizationModelId the authorization model ID
+     * @return this {@code ClientWriteOptions} instance for method chaining
+     */
     public ClientWriteOptions authorizationModelId(String authorizationModelId) {
         this.authorizationModelId = authorizationModelId;
         return this;
     }
 
+    /**
+     * Returns the authorization model ID configured for write operations.
+     *
+     * @return the authorization model ID, or {@code null} if not set
+     */
     public String getAuthorizationModelId() {
         return authorizationModelId;
     }
@@ -43,7 +68,7 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
      * @see #isTransactionsEnabled()
      */
     public ClientWriteOptions transactions(boolean enabled) {
-        this.disableTransactions = !enabled;
+        this.transactionsEnabled = enabled;
         return this;
     }
 
@@ -54,7 +79,7 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
      * @see #transactions(boolean)
      */
     public boolean isTransactionsEnabled() {
-        return disableTransactions == null || !disableTransactions;
+        return transactionsEnabled;
     }
 
     /**
@@ -69,7 +94,7 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
      */
     @Deprecated
     public ClientWriteOptions disableTransactions(boolean disableTransactions) {
-        this.disableTransactions = disableTransactions;
+        this.transactionsEnabled = !disableTransactions;
         return this;
     }
 
@@ -83,32 +108,73 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
      */
     @Deprecated
     public boolean disableTransactions() {
-        return disableTransactions != null && disableTransactions;
+        return !transactionsEnabled;
     }
 
+    /**
+     * Sets the number of tuples to include in each non-transactional write chunk.
+     *
+     * <p>Only applies when transactions are disabled via {@link #transactions(boolean)}. Writes
+     * and deletes are split into chunks of this size and sent as separate requests.
+     *
+     * @param transactionChunkSize the chunk size; must be greater than zero
+     * @return this {@code ClientWriteOptions} instance for method chaining
+     * @see #transactions(boolean)
+     */
     public ClientWriteOptions transactionChunkSize(int transactionChunkSize) {
         this.transactionChunkSize = transactionChunkSize;
         return this;
     }
 
+    /**
+     * Returns the chunk size for non-transactional writes.
+     *
+     * <p>Defaults to {@code 1} if not explicitly set.
+     *
+     * @return the configured chunk size, or {@code 1} if none was set
+     */
     public int getTransactionChunkSize() {
         return transactionChunkSize > 0 ? transactionChunkSize : 1;
     }
 
+    /**
+     * Sets the behavior when a duplicate tuple is encountered during a write.
+     *
+     * @param onDuplicate the action to take on duplicate tuples
+     * @return this {@code ClientWriteOptions} instance for method chaining
+     * @see WriteRequestWrites.OnDuplicateEnum
+     */
     public ClientWriteOptions onDuplicate(WriteRequestWrites.OnDuplicateEnum onDuplicate) {
         this.onDuplicate = onDuplicate;
         return this;
     }
 
+    /**
+     * Returns the configured behavior for duplicate tuples during writes.
+     *
+     * @return the on-duplicate action, or {@code null} if not set
+     */
     public WriteRequestWrites.OnDuplicateEnum getOnDuplicate() {
         return onDuplicate;
     }
 
+    /**
+     * Sets the behavior when a tuple to be deleted is not found.
+     *
+     * @param onMissing the action to take when a tuple is missing during delete
+     * @return this {@code ClientWriteOptions} instance for method chaining
+     * @see WriteRequestDeletes.OnMissingEnum
+     */
     public ClientWriteOptions onMissing(WriteRequestDeletes.OnMissingEnum onMissing) {
         this.onMissing = onMissing;
         return this;
     }
 
+    /**
+     * Returns the configured behavior for missing tuples during deletes.
+     *
+     * @return the on-missing action, or {@code null} if not set
+     */
     public WriteRequestDeletes.OnMissingEnum getOnMissing() {
         return onMissing;
     }


### PR DESCRIPTION
## Summary

`ClientWriteOptions.disableTransactions(boolean)` and its getter `disableTransactions()` suffer from a double-negative API design that makes call sites ambiguous — it is not obvious whether to pass `true` or `false` to achieve a given outcome, and the getter name reads confusingly in conditionals.

This PR introduces a cleaner API alongside the existing methods, maintaining full backwards compatibility.

## New API

### `transactions(boolean enabled)`

A positively-framed alternative to `disableTransactions(boolean)` — pass `true` to enable transactions (the default), `false` to disable them:

```java
// Before — what does true mean here?
new ClientWriteOptions().disableTransactions(true)

// After — unambiguous
new ClientWriteOptions().transactions(false)
```

### `isTransactionsEnabled()`

A positively-framed alternative to `disableTransactions()` (the getter), consistent with standard Java boolean getter naming conventions:

```java
// Before
if (options.disableTransactions()) { ... }

// After
if (!options.isTransactionsEnabled()) { ... }
```

## Backwards compatibility

No existing call sites are broken. Both existing methods remain fully functional and are kept as-is alongside the new API.

## Related issues

Closes #200
Relates to openfga/sdk-generator#121 (generator-wide tracking issue; left open for the other SDKs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit option to enable or disable transactions when writing data.
  * Transaction settings now default to enabled, making the behavior clearer and easier to configure.

* **Bug Fixes**
  * Improved consistency in write options so transaction-related settings behave predictably.
  * Updated option handling to keep existing defaults for chunk size and other write settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->