### PR TITLE
fix: force handlebars core to 4.5.2 to resolve path traversal CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,14 @@ ext {
     jackson_version = "2.22.0"
 }
 
+configurations.testRuntimeClasspath {
+    // handlebars 4.3.1 (pulled in by wiremock) has a path traversal CVE fixed in 4.5.2.
+    // WireMock 3.x hasn't backported the fix — only the 4.x beta line has.
+    // We force the core jar only; handlebars-helpers cannot be forced to 4.5.2 because
+    // NumberHelper moved packages between versions, which breaks WireMock at runtime.
+    resolutionStrategy.force 'com.github.jknack:handlebars:4.5.2'
+}
+
 dependencies {
     implementation "com.google.code.findbugs:jsr305:3.0.2"
 


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #11: `com.github.jknack:handlebars` < 4.5.2 is vulnerable to a path traversal attack via `FileTemplateLoader` / `ClassPathTemplateLoader` ([GHSA-r4gv-qr8j-p3pg](https://github.com/advisories/GHSA-r4gv-qr8j-p3pg)).

## Root cause

`handlebars 4.3.1` is not a direct dependency — it is pulled in transitively by `org.wiremock:wiremock:3.13.2`, which is a test-only dependency. The vulnerability was patched in `handlebars 4.5.2`, but WireMock's 3.x stable line has not backported the fix. Only the WireMock 4.x beta line (4.0.0-beta.37+) ships `handlebars 4.5.2`.

## Fix

Force `com.github.jknack:handlebars` to `4.5.2` in `testRuntimeClasspath` via Gradle's resolution strategy:

```groovy
configurations.testRuntimeClasspath {
    resolutionStrategy.force 'com.github.jknack:handlebars:4.5.2'
}
```

## Why only the core jar?

An initial attempt forced both `handlebars` and `handlebars-helpers` to `4.5.2`. This caused 33 test failures at runtime:

```
java.lang.NoClassDefFoundError: com/github/jknack/handlebars/helper/NumberHelper
```

Between 4.3.1 and 4.5.2, `NumberHelper` moved from `com.github.jknack.handlebars.helper` to `com.github.jknack.handlebars.helper.ext`. WireMock 3.x was compiled against the old package, so forcing `handlebars-helpers` to 4.5.2 breaks WireMock at runtime. The path traversal CVE is in the core `handlebars` jar only, so forcing just that jar is sufficient to resolve the alert.

## Practical risk

Low. The path traversal only affects applications that pass user-controlled input to `FileTemplateLoader.compile()`. WireMock uses handlebars internally for stub response templating with test-authored templates — there is no user-controlled input involved. However, the fix is low-risk and clears the Dependabot alert.

## Test plan

- [x] All 335 existing unit tests pass with `handlebars` forced to `4.5.2`
- [x] Confirmed failures when `handlebars-helpers` is also forced (reverted)
- [x] Dependency tree shows `handlebars:4.3.1 -> 4.5.2` after the force