### PR TITLE
fix: promote jsr305 and opentelemetry-api to api scope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ configurations.testRuntimeClasspath {
 }
 
 dependencies {
-    implementation "com.google.code.findbugs:jsr305:3.0.2"
+    api "com.google.code.findbugs:jsr305:3.0.2"
 
     // ---- Jackson ----
     api platform("com.fasterxml.jackson:jackson-bom:$jackson_version")
@@ -78,8 +78,8 @@ dependencies {
     implementation "org.openapitools:jackson-databind-nullable:0.2.10"
 
     // ---- OpenTelemetry ----
-    implementation platform("io.opentelemetry:opentelemetry-bom:1.63.0")
-    implementation "io.opentelemetry:opentelemetry-api"
+    api platform("io.opentelemetry:opentelemetry-bom:1.63.0")
+    api "io.opentelemetry:opentelemetry-api"
 }
 
 testing {


### PR DESCRIPTION
## Summary

Three dependencies were declared as `implementation` in `build.gradle` but expose their types through public method signatures. Consumers of this library need these types on the compile classpath, which `implementation` does not provide. This change promotes them to `api` scope.

**jsr305 (`@Nonnull` / `@Nullable`)**
These annotations appear on public method signatures across the model package. With `implementation` scope, downstream consumers that reference those methods cannot resolve the annotation types at compile time.

**opentelemetry-api**
`Attributes.prepare()` returns `io.opentelemetry.api.common.Attributes` and `Metrics.getMeter()` returns `io.opentelemetry.api.metrics.Meter`. Both are public methods, so the OTel types must be on the consumer compile classpath.

**opentelemetry-bom (platform)**
Promoted alongside `opentelemetry-api` so that the BOM version constraint is propagated to consumers, consistent with how the Jackson BOM is handled.

## What was not changed

- `jackson-datatype-jsr310` remains `implementation`: the module is registered internally and no JSR-310 serializer types appear in the public API.
- `jackson-databind-nullable` remains `implementation`: `JsonNullable` does not appear in any public method signature.
- Integration test dependencies are unaffected: test suites have no downstream consumers.

## Test plan

- [x] `./gradlew test` passes with no failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection against a known path traversal vulnerability in a test-related component.

* **Compatibility**
  * Improved compatibility with WireMock 3.x in test environments.

* **Library API**
  * Exposed required nullability annotations and OpenTelemetry APIs for applications integrating with the library.
  * OpenTelemetry version alignment is now consistently maintained across the published API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->