### PR TITLE
fix: migrate transaction docs and examples to transactions() API

### DIFF
--- a/examples/basic-examples/src/main/java/dev/openfga/sdk/example/Example1.java
+++ b/examples/basic-examples/src/main/java/dev/openfga/sdk/example/Example1.java
@@ -117,7 +117,7 @@ class Example1 {
                                         // relation
                                         )),
                         new ClientWriteOptions()
-                                .disableTransactions(true)
+                                .transactions(false)
                                 .authorizationModelId(authorizationModel.getAuthorizationModelId()))
                 .get();
         System.out.println("Done Writing Tuples");

--- a/examples/basic-examples/src/main/kotlin/dev/openfga/sdk/example/KotlinExample1.kt
+++ b/examples/basic-examples/src/main/kotlin/dev/openfga/sdk/example/KotlinExample1.kt
@@ -117,7 +117,7 @@ internal class KotlinExample1 {
                         )
                     ),
                 ClientWriteOptions()
-                    .disableTransactions(true)
+                    .transactions(false)
                     .authorizationModelId(authorizationModel.authorizationModelId)
             )
             .get()

--- a/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
+++ b/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
@@ -412,7 +412,7 @@ public class OpenFgaClient {
      * <p>This method can operate in two modes depending on the options provided:</p>
      *
      * <h3>Transactional Mode (default)</h3>
-     * <p>When {@code options.isTransactionsEnabled()} is true (the default):</p>
+     * <p>Used by default, when no options are passed or when {@code transactions(true)} is set:</p>
      * <ul>
      *   <li>All writes and deletes are executed as a single atomic transaction</li>
      *   <li>If any tuple fails, the entire operation fails and no changes are made</li>
@@ -421,7 +421,7 @@ public class OpenFgaClient {
      * </ul>
      *
      * <h3>Non-Transactional Mode</h3>
-     * <p>When {@code options.isTransactionsEnabled()} is false:</p>
+     * <p>Used when {@code transactions(false)} is set on the options:</p>
      * <ul>
      *   <li>Tuples are processed in chunks (size controlled by {@code transactionChunkSize})</li>
      *   <li>Each chunk is processed independently - some may succeed while others fail</li>
@@ -466,7 +466,7 @@ public class OpenFgaClient {
      * <p>This method can operate in two modes depending on the options provided:</p>
      *
      * <h3>Transactional Mode (default)</h3>
-     * <p>When {@code options.isTransactionsEnabled()} is true (the default):</p>
+     * <p>Used by default, when no options are passed or when {@code transactions(true)} is set:</p>
      * <ul>
      *   <li>All writes and deletes are executed as a single atomic transaction</li>
      *   <li>If any tuple fails, the entire operation fails and no changes are made</li>
@@ -475,7 +475,7 @@ public class OpenFgaClient {
      * </ul>
      *
      * <h3>Non-Transactional Mode</h3>
-     * <p>When {@code options.isTransactionsEnabled()} is false:</p>
+     * <p>Used when {@code transactions(false)} is set on the options:</p>
      * <ul>
      *   <li>Tuples are processed in chunks (size controlled by {@code transactionChunkSize})</li>
      *   <li>Each chunk is processed independently - some may succeed while others fail</li>

--- a/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
+++ b/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
@@ -412,7 +412,7 @@ public class OpenFgaClient {
      * <p>This method can operate in two modes depending on the options provided:</p>
      *
      * <h3>Transactional Mode (default)</h3>
-     * <p>When {@code options.disableTransactions()} is false or not set:</p>
+     * <p>When {@code options.isTransactionsEnabled()} is true (the default):</p>
      * <ul>
      *   <li>All writes and deletes are executed as a single atomic transaction</li>
      *   <li>If any tuple fails, the entire operation fails and no changes are made</li>
@@ -421,7 +421,7 @@ public class OpenFgaClient {
      * </ul>
      *
      * <h3>Non-Transactional Mode</h3>
-     * <p>When {@code options.disableTransactions()} is true:</p>
+     * <p>When {@code options.isTransactionsEnabled()} is false:</p>
      * <ul>
      *   <li>Tuples are processed in chunks (size controlled by {@code transactionChunkSize})</li>
      *   <li>Each chunk is processed independently - some may succeed while others fail</li>
@@ -466,7 +466,7 @@ public class OpenFgaClient {
      * <p>This method can operate in two modes depending on the options provided:</p>
      *
      * <h3>Transactional Mode (default)</h3>
-     * <p>When {@code options.disableTransactions()} is false or not set:</p>
+     * <p>When {@code options.isTransactionsEnabled()} is true (the default):</p>
      * <ul>
      *   <li>All writes and deletes are executed as a single atomic transaction</li>
      *   <li>If any tuple fails, the entire operation fails and no changes are made</li>
@@ -475,7 +475,7 @@ public class OpenFgaClient {
      * </ul>
      *
      * <h3>Non-Transactional Mode</h3>
-     * <p>When {@code options.disableTransactions()} is true:</p>
+     * <p>When {@code options.isTransactionsEnabled()} is false:</p>
      * <ul>
      *   <li>Tuples are processed in chunks (size controlled by {@code transactionChunkSize})</li>
      *   <li>Each chunk is processed independently - some may succeed while others fail</li>
@@ -515,7 +515,7 @@ public class OpenFgaClient {
         configuration.assertValid();
         String storeId = configuration.getStoreIdChecked();
 
-        if (options != null && options.disableTransactions()) {
+        if (options != null && !options.isTransactionsEnabled()) {
             return writeNonTransaction(storeId, request, options);
         }
 

--- a/src/test-integration/java/dev/openfga/sdk/example/Example1.java
+++ b/src/test-integration/java/dev/openfga/sdk/example/Example1.java
@@ -117,7 +117,7 @@ class Example1 {
                                         // relation
                                         )),
                         new ClientWriteOptions()
-                                .disableTransactions(true)
+                                .transactions(false)
                                 .authorizationModelId(authorizationModel.getAuthorizationModelId()))
                 .get();
         System.out.println("Done Writing Tuples");


### PR DESCRIPTION
## Summary

Moves the write transaction docs and examples off the double-negative `disableTransactions(boolean)` to the affirmative `transactions(boolean)` / `isTransactionsEnabled()` API added in #352. Both APIs coexist today; this stops the SDK's own docs, examples, and internal code from teaching or using the method slated for deprecation.

## Changes

- `OpenFgaClient.java`: the `write` mode-selection Javadoc (both overloads) now describes behavior via `isTransactionsEnabled()` instead of `disableTransactions()`.
- `OpenFgaClient.java`: the internal write-mode branch changed from `options.disableTransactions()` to `!options.isTransactionsEnabled()`, so the SDK no longer calls its own soon-to-be-deprecated method.
- Example projects switched from `.disableTransactions(true)` to `.transactions(false)`: `examples/basic-examples` (Java and Kotlin) and `src/test-integration`.

Behavior is unchanged. `transactions(false)` is exactly equivalent to the prior `disableTransactions(true)`, and `!isTransactionsEnabled()` equals the prior `disableTransactions()`.

## Out of scope

- Test call sites in `OpenFgaClientTest`, `OpenFgaClientHeadersTest`, and `OpenFgaClientWriteResponseHeadersTest` still call `disableTransactions(...)`. These are migrated in the deprecation issue (#369), which will move most of them to `transactions(...)` and keep one back-compat test under `@SuppressWarnings("deprecation")`. This ordering is what keeps the build warning-free once deprecation lands.
- `README.md` write examples: generated from openfga/sdk-generator and already updated via #372.
- Adding `@Deprecated` to the old methods: separate issue (#369), gated on this change shipping in a release.

## Verification

Changes verified by inspection: `transactions(boolean)` and `isTransactionsEnabled()` exist on `ClientWriteOptions`, and the logic is a direct equivalence swap. A local compile could not run here because dependency resolution against the private Artifactory mirror returns 401; CI performs the authoritative compile and test.

## Why now

Step 1 of retiring `disableTransactions`. Review on #352 flagged that the SDK's own docs and examples still teach the double-negative method. The old methods cannot be deprecated until the docs and examples stop teaching them, and the deprecation stays blocked until this change ships in a release.

Closes #368


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated tuple write configuration examples to use the clearer `transactions(false)` option.
  * Write operations now consistently honor the configured transaction mode.
  * Non-transactional writes continue processing in chunks when transactions are disabled.
  * Updated accompanying API documentation and examples to reflect the current configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->