### PR TITLE
ci: fix version extraction regex in verify-version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,8 +59,10 @@ jobs:
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           MANIFEST_VERSION=$(jq -r '.["."]' .release-please-manifest.json)
-          GRADLE_VERSION=$(grep 'x-release-please-version' build.gradle | grep -oP "'\K[^']+")
-          PUBLISH_VERSION=$(grep 'x-release-please-version' publish.gradle | grep -oP "'\K[^']+")
+          # The (?=') lookahead requires a closing quote, so the trailing
+          # marker comment is not captured as a second match.
+          GRADLE_VERSION=$(grep 'x-release-please-version' build.gradle | grep -oP "'\K[^']+(?=')")
+          PUBLISH_VERSION=$(grep 'x-release-please-version' publish.gradle | grep -oP "'\K[^']+(?=')")
 
           echo "Tag: $TAG_VERSION | Manifest: $MANIFEST_VERSION | build.gradle: $GRADLE_VERSION | publish.gradle: $PUBLISH_VERSION"
 


### PR DESCRIPTION
## Problem

The `verify-version` job fails on every tagged release. It blocked the `v0.9.10` release: [run 30894824034](https://github.com/openfga/java-sdk/actions/runs/30894824034/job/91945811556).

The job logs show the version being printed across two lines:

```
Tag: 0.9.10 | Manifest: 0.9.10 | build.gradle: 0.9.10
 // x-release-please-version | publish.gradle: 0.9.10
 // x-release-please-version
ERROR: build.gradle version does not match manifest version
```

## Root cause

The extraction used:

```bash
grep -oP "'\K[^']+"
```

`[^']+` has no closing-quote requirement, so on a line like

```groovy
version = '0.9.10' // x-release-please-version
```

it matched **twice** — once for `0.9.10`, and again for everything after the second quote (` // x-release-please-version`). Command substitution joined both matches with a newline, so `$GRADLE_VERSION` became a two-line string that could never compare equal to `0.9.10`.

## Fix

Add a `(?=')` lookahead so the match must terminate at a closing quote. The marker comment is no longer captured. This is the same idiom already used correctly in [openfga/go-sdk](https://github.com/openfga/go-sdk/blob/main/.github/workflows/main.yaml).

## Notes

- This check was added in 8c36b13, *after* `v0.9.9` was tagged, so `v0.9.10` was the first tag to ever reach it — it has never passed.
- The pipeline failed closed, before any publish step. Maven Central has no `0.9.10`, GitHub Packages never ran, and the GitHub release is still a draft. Nothing was partially published.
- `dotnet-sdk` uses a similar pattern but is **not** affected (its marker is `<!-- ... -->`, and `[^<]+` cannot match across the newline). `go-sdk` is already correct.

## Testing

Verified against GNU grep on `ubuntu:24.04` (the runner image), since macOS/BSD grep lacks `-P`:

```
Tag: 0.9.10 | Manifest: 0.9.10 | build.gradle: 0.9.10 | publish.gradle: 0.9.10
All versions verified: 0.9.10
```

Also confirmed the check still fails correctly when a version genuinely diverges, so the guardrail is preserved rather than weakened.

## Follow-up

`v0.9.10` cannot be recovered by re-running the failed job: a tag-push run executes the workflow file from the tag's own tree, which still contains the buggy line. The tag rulesets (`Restrict Tag Deletions`, `Enforce Tag Creation`) are active with no bypass actors, so the tag cannot be moved either. Once this merges, the release will be re-cut as `0.9.11` and the stale `v0.9.10` draft release cleaned up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection during builds and publishing to prevent trailing release comments from being included in version numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->