### PR TITLE
fix: deprecate disableTransactions in favour of transactions()

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/configuration/ClientWriteOptions.java
+++ b/src/main/java/dev/openfga/sdk/api/configuration/ClientWriteOptions.java
@@ -88,7 +88,12 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
      *
      * @param disableTransactions {@code true} to disable transactions, {@code false} to enable them
      * @return this {@code ClientWriteOptions} instance for method chaining
+     * @deprecated Use {@link #transactions(boolean)} instead. This method will be removed in a
+     *     future release. Replace {@code disableTransactions(true)} with
+     *     {@code transactions(false)}, and {@code disableTransactions(false)} with
+     *     {@code transactions(true)}.
      */
+    @Deprecated
     public ClientWriteOptions disableTransactions(boolean disableTransactions) {
         this.transactionsEnabled = !disableTransactions;
         return this;
@@ -98,7 +103,11 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
      * Returns whether transactions are disabled for write operations.
      *
      * @return {@code true} if transactions are disabled, {@code false} if enabled (default)
+     * @deprecated Use {@link #isTransactionsEnabled()} instead. This method will be removed in a
+     *     future release. Note that {@code isTransactionsEnabled()} returns the inverse of
+     *     this method.
      */
+    @Deprecated
     public boolean disableTransactions() {
         return !transactionsEnabled;
     }

--- a/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientHeadersTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientHeadersTest.java
@@ -440,7 +440,7 @@ public class OpenFgaClientHeadersTest {
                         .user(DEFAULT_USER)));
         ClientWriteOptions options = new ClientWriteOptions()
                 .additionalHeaders(Map.of("test-header", "test-value-per-call"))
-                .disableTransactions(true);
+                .transactions(false);
 
         // When
         ClientWriteResponse response = fga.write(request, options).get();

--- a/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
@@ -1285,7 +1285,7 @@ public class OpenFgaClientTest {
                 .writes(List.of(writeTuple, writeTuple, writeTuple, writeTuple, writeTuple))
                 .deletes(List.of(tuple, tuple, tuple, tuple, tuple));
         ClientWriteOptions options =
-                new ClientWriteOptions().disableTransactions(true).transactionChunkSize(2);
+                new ClientWriteOptions().transactions(false).transactionChunkSize(2);
 
         // When
         var response = fga.write(request, options).get();
@@ -1353,7 +1353,7 @@ public class OpenFgaClientTest {
                                 .condition(DEFAULT_CONDITION))
                         .collect(Collectors.toList()));
         ClientWriteOptions options =
-                new ClientWriteOptions().disableTransactions(true).transactionChunkSize(1);
+                new ClientWriteOptions().transactions(false).transactionChunkSize(1);
 
         // When
         ClientWriteResponse response = fga.write(request, options).get();
@@ -1430,7 +1430,7 @@ public class OpenFgaClientTest {
 
         // We expect transactionChunkSize will be ignored, and exactly one request will be sent.
         ClientWriteOptions options =
-                new ClientWriteOptions().disableTransactions(false).transactionChunkSize(1);
+                new ClientWriteOptions().transactions(true).transactionChunkSize(1);
 
         // When
         var response = fga.write(request, options).get();
@@ -1473,7 +1473,7 @@ public class OpenFgaClientTest {
 
         // We expect transactionChunkSize will be ignored, and exactly one request will be sent.
         ClientWriteOptions options =
-                new ClientWriteOptions().disableTransactions(false).transactionChunkSize(1);
+                new ClientWriteOptions().transactions(true).transactionChunkSize(1);
 
         // When
         var execException = assertThrows(
@@ -1683,7 +1683,7 @@ public class OpenFgaClientTest {
         ClientWriteRequest request =
                 new ClientWriteRequest().writes(List.of(writeTuple)).deletes(List.of(deleteTuple));
         ClientWriteOptions options = new ClientWriteOptions()
-                .disableTransactions(true)
+                .transactions(false)
                 .onDuplicate(WriteRequestWrites.OnDuplicateEnum.IGNORE)
                 .onMissing(WriteRequestDeletes.OnMissingEnum.IGNORE);
 

--- a/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
@@ -1429,8 +1429,7 @@ public class OpenFgaClientTest {
                 new ClientWriteRequest().writes(List.of(tuple, tuple, tuple)).deletes(List.of(tuple, tuple, tuple));
 
         // We expect transactionChunkSize will be ignored, and exactly one request will be sent.
-        ClientWriteOptions options =
-                new ClientWriteOptions().transactions(true).transactionChunkSize(1);
+        ClientWriteOptions options = new ClientWriteOptions().transactions(true).transactionChunkSize(1);
 
         // When
         var response = fga.write(request, options).get();
@@ -1472,8 +1471,7 @@ public class OpenFgaClientTest {
                 new ClientWriteRequest().writes(List.of(tuple, tuple, tuple)).deletes(List.of(tuple, tuple, tuple));
 
         // We expect transactionChunkSize will be ignored, and exactly one request will be sent.
-        ClientWriteOptions options =
-                new ClientWriteOptions().transactions(true).transactionChunkSize(1);
+        ClientWriteOptions options = new ClientWriteOptions().transactions(true).transactionChunkSize(1);
 
         // When
         var execException = assertThrows(

--- a/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientWriteResponseHeadersTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientWriteResponseHeadersTest.java
@@ -172,7 +172,7 @@ public class OpenFgaClientWriteResponseHeadersTest {
                         .relation(DEFAULT_RELATION)
                         ._object(DEFAULT_OBJECT)));
 
-        ClientWriteOptions options = new ClientWriteOptions().disableTransactions(true);
+        ClientWriteOptions options = new ClientWriteOptions().transactions(false);
 
         // When
         ClientWriteResponse response = fgaClient.write(request, options).get();

--- a/src/test/java/dev/openfga/sdk/api/configuration/ClientWriteOptionsTest.java
+++ b/src/test/java/dev/openfga/sdk/api/configuration/ClientWriteOptionsTest.java
@@ -1,0 +1,44 @@
+package dev.openfga.sdk.api.configuration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ClientWriteOptionsTest {
+
+    @Test
+    void transactionsEnabledByDefault() {
+        ClientWriteOptions options = new ClientWriteOptions();
+
+        assertTrue(options.isTransactionsEnabled());
+    }
+
+    @Test
+    void transactionsFalseDisablesTransactions() {
+        ClientWriteOptions options = new ClientWriteOptions().transactions(false);
+
+        assertFalse(options.isTransactionsEnabled());
+    }
+
+    /**
+     * Covers the deprecated {@code disableTransactions} methods and asserts they remain the exact
+     * inverse of {@code transactions}/{@code isTransactionsEnabled}. This is the one place the
+     * deprecated path is exercised on purpose; the suppression keeps the rest of the build
+     * warning-free. Remove this test when the deprecated methods are removed.
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    void deprecatedDisableTransactionsRemainsInverseOfTransactions() {
+        // transactions(false) implies disableTransactions() == true
+        assertTrue(new ClientWriteOptions().transactions(false).disableTransactions());
+
+        // transactions(true) implies disableTransactions() == false
+        assertFalse(new ClientWriteOptions().transactions(true).disableTransactions());
+
+        // disableTransactions(true) implies isTransactionsEnabled() == false
+        assertFalse(new ClientWriteOptions().disableTransactions(true).isTransactionsEnabled());
+
+        // disableTransactions(false) implies isTransactionsEnabled() == true
+        assertTrue(new ClientWriteOptions().disableTransactions(false).isTransactionsEnabled());
+    }
+}


### PR DESCRIPTION
## Summary

Deprecates `ClientWriteOptions.disableTransactions(boolean)` and `disableTransactions()` in favour of the affirmative `transactions(boolean)` / `isTransactionsEnabled()` API added in #352. This is step 2 of retiring the double-negative methods.

The deprecation was intentionally held until the docs and examples stopped teaching the old methods (step 1) and the new API shipped in a release. Both conditions are now met: #718, #368, and #186 are merged, and `transactions()` is published in 0.9.11.

## Changes

- `ClientWriteOptions.java`: `@Deprecated` re-applied to both `disableTransactions` overloads, each with a `@deprecated` Javadoc tag naming the replacement and the migration mapping.
- Migrated the internal test call sites to `transactions(...)` so the build stays warning-free: `OpenFgaClientTest` (5 sites), `OpenFgaClientHeadersTest`, `OpenFgaClientWriteResponseHeadersTest`.
- Added `ClientWriteOptionsTest` covering the default, the `transactions(false)` path, and a `@SuppressWarnings("deprecation")` case asserting `disableTransactions` remains the exact inverse of `transactions` / `isTransactionsEnabled`, so the deprecated path stays covered.

The methods still work; only the annotation and docs change. `disableTransactions(true)` equals `transactions(false)`, and `disableTransactions()` is the inverse of `isTransactionsEnabled()`.

## Zero-warning result

After this change the only references to `disableTransactions` are the deprecated definitions and the single suppressed back-compat test. No unsuppressed caller remains, so no deprecation warnings are produced. `build.gradle` does not treat deprecation as an error today, but the intent is a warning-free build regardless.

## Verification

Changes verified by inspection: both overloads carry `@Deprecated`; the six migrated sites use `transactions(...)`; the new test references only methods that exist on `ClientWriteOptions`. A local build could not run here because dependency resolution is routed through a private mirror that returns 401 in this environment; CI performs the authoritative compile and test.

## Notes

- CHANGELOG is release-please-generated from commit messages, so it is not hand-edited. The deprecation is recorded via this PR's conventional-commit message and will appear in the changelog on the next release.
- Removal of the methods is a separate breaking change tracked in #370, gated on this deprecation shipping plus one release cycle.

Closes #369


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance and deprecation notices for the legacy transaction-disabling options.
  * Continued support for existing behavior while directing users to the current transaction configuration APIs.

* **Tests**
  * Expanded coverage for transaction settings, including defaults and enabled or disabled transactions.
  * Updated write-operation tests to use the current transaction configuration methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->