### PR TITLE
fix: expose error status, headers and body on failed clientBatchCheck items

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/client/model/ClientBatchCheckClientResponse.java
+++ b/src/main/java/dev/openfga/sdk/api/client/model/ClientBatchCheckClientResponse.java
@@ -75,14 +75,30 @@ public class ClientBatchCheckClientResponse extends CheckResponse {
         return throwable;
     }
 
-    public int getStatusCode() {
+    /**
+     * Returns the HTTP status code of the check response.
+     * <p>
+     * If no HTTP response was received — for example, the request never reached the server because of a
+     * network failure (connection refused, timeout, DNS failure) and all retries were exhausted — this
+     * returns {@code null}. In that case the underlying cause can be examined with
+     * {@link ClientBatchCheckClientResponse#getThrowable()}.
+     *
+     * @return the HTTP status code, or {@code null} if no HTTP response was received.
+     */
+    public Integer getStatusCode() {
         return statusCode;
     }
 
+    /**
+     * @return the HTTP response headers, or {@code null} if no HTTP response was received.
+     */
     public Map<String, List<String>> getHeaders() {
         return headers;
     }
 
+    /**
+     * @return the raw HTTP response body, or {@code null} if no HTTP response was received.
+     */
     public String getRawResponse() {
         return rawResponse;
     }

--- a/src/main/java/dev/openfga/sdk/api/client/model/ClientBatchCheckClientResponse.java
+++ b/src/main/java/dev/openfga/sdk/api/client/model/ClientBatchCheckClientResponse.java
@@ -4,6 +4,8 @@ import dev.openfga.sdk.api.model.CheckResponse;
 import dev.openfga.sdk.errors.FgaError;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 
 public class ClientBatchCheckClientResponse extends CheckResponse {
@@ -18,19 +20,24 @@ public class ClientBatchCheckClientResponse extends CheckResponse {
         this.request = request;
         this.throwable = throwable;
 
+        Throwable cause = throwable instanceof CompletionException || throwable instanceof ExecutionException
+                ? throwable.getCause()
+                : throwable;
+
         if (clientCheckResponse != null) {
             this.statusCode = clientCheckResponse.getStatusCode();
             this.headers = clientCheckResponse.getHeaders();
             this.rawResponse = clientCheckResponse.getRawResponse();
             this.setAllowed(clientCheckResponse.getAllowed());
             this.setResolution(clientCheckResponse.getResolution());
-        } else if (throwable instanceof FgaError) {
-            FgaError error = (FgaError) throwable;
+        } else if (cause instanceof FgaError) {
+            FgaError error = (FgaError) cause;
             this.statusCode = error.getStatusCode();
-            this.headers = error.getResponseHeaders().map();
+            var responseHeaders = error.getResponseHeaders();
+            this.headers = responseHeaders != null ? responseHeaders.map() : null;
             this.rawResponse = error.getResponseData();
         } else {
-            // Should be unreachable, but required for type completion
+            // no HTTP response available, e.g. the request never reached the server
             this.statusCode = null;
             this.headers = null;
             this.rawResponse = null;

--- a/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
@@ -2066,6 +2066,11 @@ public class OpenFgaClientTest {
         assertNotNull(response);
         assertEquals(1, response.size());
         assertNull(response.get(0).getAllowed());
+        assertEquals(400, response.get(0).getStatusCode());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                response.get(0).getRawResponse());
+        assertNotNull(response.get(0).getHeaders());
         Throwable execException = response.get(0).getThrowable();
         var exception = assertInstanceOf(FgaApiValidationError.class, execException.getCause());
         assertEquals(400, exception.getStatusCode());
@@ -2092,6 +2097,11 @@ public class OpenFgaClientTest {
         assertNotNull(response);
         assertEquals(1, response.size());
         assertNull(response.get(0).getAllowed());
+        assertEquals(404, response.get(0).getStatusCode());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}",
+                response.get(0).getRawResponse());
+        assertNotNull(response.get(0).getHeaders());
         Throwable execException = response.get(0).getThrowable();
         var exception = assertInstanceOf(FgaApiNotFoundError.class, execException.getCause());
         assertEquals(404, exception.getStatusCode());
@@ -2118,6 +2128,11 @@ public class OpenFgaClientTest {
         assertNotNull(response);
         assertEquals(1, response.size());
         assertNull(response.get(0).getAllowed());
+        assertEquals(500, response.get(0).getStatusCode());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}",
+                response.get(0).getRawResponse());
+        assertNotNull(response.get(0).getHeaders());
         Throwable execException = response.get(0).getThrowable();
         var exception = assertInstanceOf(FgaApiInternalError.class, execException.getCause());
         assertEquals(500, exception.getStatusCode());

--- a/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.pgssoft.httpclient.HttpClientMock;
@@ -18,6 +19,7 @@ import dev.openfga.sdk.api.configuration.*;
 import dev.openfga.sdk.api.model.*;
 import dev.openfga.sdk.constants.FgaConstants;
 import dev.openfga.sdk.errors.*;
+import java.io.IOException;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -2138,6 +2140,41 @@ public class OpenFgaClientTest {
         assertEquals(500, exception.getStatusCode());
         assertEquals(
                 "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseData());
+    }
+
+    @Test
+    public void clientBatchCheck_networkError(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        // Given
+        String httpBaseUrl = wireMockRuntimeInfo.getHttpBaseUrl();
+        var fga = new OpenFgaClient(clientConfiguration.apiUrl(httpBaseUrl), new ApiClient());
+        String postUrl = String.format("/stores/%s/check", DEFAULT_STORE_ID);
+        WireMock.stubFor(
+                WireMock.post(postUrl).willReturn(WireMock.aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        // When
+        List<ClientBatchCheckClientResponse> response = fga.clientBatchCheck(
+                        List.of(new ClientCheckRequest()), new ClientBatchCheckClientOptions())
+                .join();
+
+        // Then
+        // Network errors are retried (1 initial + 3 retries = 4 total)
+        WireMock.verify(4, WireMock.postRequestedFor(WireMock.urlEqualTo(postUrl)));
+        assertNotNull(response);
+        assertEquals(1, response.size());
+        assertNull(response.get(0).getAllowed());
+        // No HTTP response was received, so status code, headers and body are null
+        assertNull(response.get(0).getStatusCode());
+        assertNull(response.get(0).getHeaders());
+        assertNull(response.get(0).getRawResponse());
+        Throwable execException = response.get(0).getThrowable();
+        assertNotNull(execException);
+        var exception = assertInstanceOf(ApiException.class, execException.getCause());
+        assertFalse(exception instanceof FgaError);
+        Throwable rootCause = exception;
+        while (rootCause.getCause() != null) {
+            rootCause = rootCause.getCause();
+        }
+        assertInstanceOf(IOException.class, rootCause);
     }
 
     @Test


### PR DESCRIPTION


The throwable passed to ClientBatchCheckClientResponse is the CompletionException from the check future, so the instanceof FgaError branch never matched and statusCode, headers and rawResponse stayed null, making getStatusCode() throw NullPointerException. Unwrap the wrapper exception before the check.

Fixes #380

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch check error handling by correctly unwrapping underlying exceptions.
  * Preserved HTTP status codes, response bodies, and headers when available, including cases without an HTTP response.

* **Tests**
  * Expanded error-handling coverage for batch checks returning 400, 404, and 500 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->