### PR TITLE
feat: add json serialization bridge

### DIFF
--- a/src/main/java/dev/openfga/sdk/api/BaseStreamingApi.java
+++ b/src/main/java/dev/openfga/sdk/api/BaseStreamingApi.java
@@ -14,9 +14,9 @@ package dev.openfga.sdk.api;
 
 import static dev.openfga.sdk.util.StringUtil.isNullOrWhitespace;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.openfga.sdk.api.client.ApiClient;
+import dev.openfga.sdk.api.client.JsonSerializer;
+import dev.openfga.sdk.api.client.SdkTypeToken;
 import dev.openfga.sdk.api.configuration.Configuration;
 import dev.openfga.sdk.api.model.Status;
 import dev.openfga.sdk.api.model.StreamResult;
@@ -38,22 +38,22 @@ import java.util.stream.Stream;
 public abstract class BaseStreamingApi<T> {
     protected final Configuration configuration;
     protected final ApiClient apiClient;
-    protected final ObjectMapper objectMapper;
-    protected final TypeReference<StreamResult<T>> streamResultTypeRef;
+    protected final JsonSerializer jsonSerializer;
+    protected final SdkTypeToken<StreamResult<T>> streamResultType;
 
     /**
      * Constructor for BaseStreamingApi
      *
      * @param configuration The API configuration
      * @param apiClient The API client for making HTTP requests
-     * @param streamResultTypeRef TypeReference for deserializing StreamResult<T>
+     * @param streamResultType SDK type token for deserializing StreamResult<T>
      */
     protected BaseStreamingApi(
-            Configuration configuration, ApiClient apiClient, TypeReference<StreamResult<T>> streamResultTypeRef) {
+            Configuration configuration, ApiClient apiClient, SdkTypeToken<StreamResult<T>> streamResultType) {
         this.configuration = configuration;
         this.apiClient = apiClient;
-        this.objectMapper = apiClient.getObjectMapper();
-        this.streamResultTypeRef = streamResultTypeRef;
+        this.jsonSerializer = apiClient.getJsonSerializer();
+        this.streamResultType = streamResultType;
     }
 
     /**
@@ -126,7 +126,7 @@ public abstract class BaseStreamingApi<T> {
     private void processLine(String line, Consumer<T> consumer, Consumer<Throwable> errorConsumer) {
         try {
             // Parse the JSON line to extract the object
-            StreamResult<T> streamResult = objectMapper.readValue(line, streamResultTypeRef);
+            StreamResult<T> streamResult = jsonSerializer.readValue(line, streamResultType);
 
             if (streamResult.getError() != null) {
                 // Handle error in stream
@@ -165,7 +165,7 @@ public abstract class BaseStreamingApi<T> {
     protected HttpRequest buildHttpRequest(String method, String path, Object body, Configuration configuration)
             throws ApiException, FgaInvalidParameterException {
         try {
-            byte[] bodyBytes = objectMapper.writeValueAsBytes(body);
+            byte[] bodyBytes = jsonSerializer.writeValueAsBytes(body);
             HttpRequest.Builder requestBuilder = ApiClient.requestBuilder(method, path, bodyBytes, configuration);
 
             apiClient.applyAuthHeader(requestBuilder, configuration);

--- a/src/main/java/dev/openfga/sdk/api/OpenFgaApi.java
+++ b/src/main/java/dev/openfga/sdk/api/OpenFgaApi.java
@@ -1265,7 +1265,7 @@ public class OpenFgaApi {
     private <T> HttpRequest buildHttpRequest(String method, String path, T body, Configuration configuration)
             throws ApiException, FgaInvalidParameterException {
         try {
-            byte[] localVarPostBody = apiClient.getObjectMapper().writeValueAsBytes(body);
+            byte[] localVarPostBody = apiClient.getJsonSerializer().writeValueAsBytes(body);
             var bodyPublisher = HttpRequest.BodyPublishers.ofByteArray(localVarPostBody);
             return buildHttpRequestWithPublisher(method, path, bodyPublisher, configuration);
         } catch (IOException e) {

--- a/src/main/java/dev/openfga/sdk/api/StreamedListObjectsApi.java
+++ b/src/main/java/dev/openfga/sdk/api/StreamedListObjectsApi.java
@@ -14,8 +14,8 @@ package dev.openfga.sdk.api;
 
 import static dev.openfga.sdk.util.Validation.assertParamExists;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import dev.openfga.sdk.api.client.ApiClient;
+import dev.openfga.sdk.api.client.SdkTypeToken;
 import dev.openfga.sdk.api.configuration.Configuration;
 import dev.openfga.sdk.api.configuration.ConfigurationOverride;
 import dev.openfga.sdk.api.model.ListObjectsRequest;
@@ -36,7 +36,10 @@ import java.util.function.Consumer;
 public class StreamedListObjectsApi extends BaseStreamingApi<StreamedListObjectsResponse> {
 
     public StreamedListObjectsApi(Configuration configuration, ApiClient apiClient) {
-        super(configuration, apiClient, new TypeReference<StreamResult<StreamedListObjectsResponse>>() {});
+        super(
+                configuration,
+                apiClient,
+                SdkTypeToken.parameterized(StreamResult.class, StreamedListObjectsResponse.class));
     }
 
     /**

--- a/src/main/java/dev/openfga/sdk/api/client/ApiClient.java
+++ b/src/main/java/dev/openfga/sdk/api/client/ApiClient.java
@@ -2,11 +2,7 @@ package dev.openfga.sdk.api.client;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dev.openfga.sdk.api.auth.OAuth2Client;
 import dev.openfga.sdk.api.configuration.ClientCredentials;
 import dev.openfga.sdk.api.configuration.Configuration;
@@ -30,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
-import org.openapitools.jackson.nullable.JsonNullableModule;
 
 /**
  * Configuration and utility class for API clients.
@@ -49,7 +44,7 @@ public class ApiClient {
 
     private HttpClient.Builder builder;
     private HttpClient client;
-    private ObjectMapper mapper;
+    private JsonSerializer jsonSerializer;
     private Consumer<HttpRequest.Builder> interceptor;
     private Consumer<HttpResponse<InputStream>> responseInterceptor;
     private Consumer<HttpResponse<String>> asyncResponseInterceptor;
@@ -60,7 +55,7 @@ public class ApiClient {
      */
     public ApiClient() {
         this.builder = createDefaultHttpClientBuilder();
-        this.mapper = createDefaultObjectMapper();
+        this.jsonSerializer = JsonSerializer.createDefault();
         this.client = this.builder.build();
         interceptor = null;
         responseInterceptor = null;
@@ -78,7 +73,7 @@ public class ApiClient {
      */
     public ApiClient(HttpClient.Builder builder) {
         this.builder = builder;
-        this.mapper = createDefaultObjectMapper();
+        this.jsonSerializer = JsonSerializer.createDefault();
         this.client = this.builder.build();
         interceptor = null;
         responseInterceptor = null;
@@ -94,10 +89,22 @@ public class ApiClient {
      *
      * @param builder Http client builder.
      * @param mapper Object mapper.
+     * @deprecated Use {@link #ApiClient(HttpClient.Builder, JsonSerializer)}.
      */
+    @Deprecated(since = "0.11.0")
     public ApiClient(HttpClient.Builder builder, ObjectMapper mapper) {
+        this(builder, new Jackson2JsonSerializer(mapper));
+    }
+
+    /**
+     * Create an instance of ApiClient.
+     *
+     * @param builder Http client builder.
+     * @param jsonSerializer JSON serializer.
+     */
+    public ApiClient(HttpClient.Builder builder, JsonSerializer jsonSerializer) {
         this.builder = builder;
-        this.mapper = mapper;
+        this.jsonSerializer = Objects.requireNonNull(jsonSerializer, "JsonSerializer cannot be null");
         this.client = this.builder.build();
         interceptor = null;
         responseInterceptor = null;
@@ -168,20 +175,6 @@ public class ApiClient {
         return URLEncoder.encode(s, UTF_8).replaceAll("\\+", "%20");
     }
 
-    protected ObjectMapper createDefaultObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
-        mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
-        mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
-        mapper.registerModule(new JavaTimeModule());
-        mapper.registerModule(new JsonNullableModule());
-        return mapper;
-    }
-
     protected String getDefaultBaseUri() {
         return "http://localhost";
     }
@@ -230,24 +223,41 @@ public class ApiClient {
     }
 
     /**
-     * Set a custom {@link ObjectMapper} to serialize and deserialize the request
-     * and response bodies.
+     * Set a custom {@link ObjectMapper} for request and response bodies.
      *
      * @param mapper Custom object mapper.
      * @return This object.
+     * @deprecated Use {@link #setJsonSerializer(JsonSerializer)}.
      */
+    @Deprecated(since = "0.11.0")
     public ApiClient setObjectMapper(ObjectMapper mapper) {
-        this.mapper = mapper;
-        return this;
+        return setJsonSerializer(new Jackson2JsonSerializer(mapper));
     }
 
     /**
-     * Get current {@link ObjectMapper}.
+     * Get the current Jackson 2 object mapper.
      *
-     * @return the current object mapper.
+     * @return Current Jackson 2 object mapper.
+     * @throws UnsupportedOperationException if the active serializer does not use Jackson 2.
+     * @deprecated Use {@link #getJsonSerializer()}.
      */
+    @Deprecated(since = "0.11.0")
     public ObjectMapper getObjectMapper() {
-        return mapper;
+        if (jsonSerializer instanceof Jackson2JsonSerializer) {
+            return ((Jackson2JsonSerializer) jsonSerializer).getObjectMapper();
+        }
+        throw new UnsupportedOperationException("The active JSON serializer does not use Jackson 2");
+    }
+
+    /** Set the serializer for request and response bodies. */
+    public ApiClient setJsonSerializer(JsonSerializer jsonSerializer) {
+        this.jsonSerializer = Objects.requireNonNull(jsonSerializer, "JsonSerializer cannot be null");
+        return this;
+    }
+
+    /** Get the serializer for request and response bodies. */
+    public JsonSerializer getJsonSerializer() {
+        return jsonSerializer;
     }
 
     /**

--- a/src/main/java/dev/openfga/sdk/api/client/ApiExecutor.java
+++ b/src/main/java/dev/openfga/sdk/api/client/ApiExecutor.java
@@ -4,7 +4,6 @@ import dev.openfga.sdk.api.configuration.Configuration;
 import dev.openfga.sdk.errors.ApiException;
 import dev.openfga.sdk.errors.FgaInvalidParameterException;
 import dev.openfga.sdk.telemetry.Telemetry;
-import java.io.IOException;
 import java.net.http.HttpRequest;
 import java.util.concurrent.CompletableFuture;
 
@@ -103,9 +102,8 @@ public class ApiExecutor {
 
             return new HttpRequestAttempt<>(httpRequest, methodName, responseType, apiClient, configuration, telemetry)
                     .attemptHttpRequest();
-
-        } catch (IOException e) {
-            return CompletableFuture.failedFuture(new ApiException(e));
+        } catch (dev.openfga.sdk.errors.SdkSerializationException error) {
+            return CompletableFuture.failedFuture(new ApiException(error));
         }
     }
 }

--- a/src/main/java/dev/openfga/sdk/api/client/ApiExecutorRequestBuilder.java
+++ b/src/main/java/dev/openfga/sdk/api/client/ApiExecutorRequestBuilder.java
@@ -1,10 +1,10 @@
 package dev.openfga.sdk.api.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.openfga.sdk.api.configuration.ClientConfiguration;
 import dev.openfga.sdk.api.configuration.Configuration;
 import dev.openfga.sdk.errors.ApiException;
 import dev.openfga.sdk.errors.FgaInvalidParameterException;
+import dev.openfga.sdk.errors.SdkSerializationException;
 import dev.openfga.sdk.util.StringUtil;
 import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
@@ -193,14 +193,14 @@ public class ApiExecutorRequestBuilder {
      * Package-private — used by {@link ApiExecutor} and {@link StreamingApiExecutor}.
      */
     HttpRequest buildHttpRequest(Configuration configuration, ApiClient apiClient)
-            throws ApiException, FgaInvalidParameterException, JsonProcessingException {
+            throws ApiException, FgaInvalidParameterException, SdkSerializationException {
         String resolvedPath = buildPath(configuration);
 
         HttpRequest.Builder httpRequestBuilder;
         if (hasBody()) {
             byte[] bodyBytes = body instanceof String
                     ? ((String) body).getBytes(StandardCharsets.UTF_8)
-                    : apiClient.getObjectMapper().writeValueAsBytes(body);
+                    : apiClient.getJsonSerializer().writeValueAsBytes(body);
             httpRequestBuilder = ApiClient.requestBuilder(method.name(), resolvedPath, bodyBytes, configuration);
         } else {
             httpRequestBuilder = ApiClient.requestBuilder(method.name(), resolvedPath, configuration);

--- a/src/main/java/dev/openfga/sdk/api/client/HttpRequestAttempt.java
+++ b/src/main/java/dev/openfga/sdk/api/client/HttpRequestAttempt.java
@@ -171,7 +171,8 @@ public class HttpRequestAttempt<T> {
 
     private CompletableFuture<ApiResponse<T>> processHttpResponse(
             HttpResponse<String> response, int retryNumber, Throwable previousError) {
-        Optional<FgaError> fgaError = FgaError.getError(name, request, configuration, response, previousError);
+        Optional<FgaError> fgaError =
+                FgaError.getError(name, request, configuration, response, previousError, apiClient.getJsonSerializer());
 
         if (fgaError.isPresent()) {
             FgaError error = fgaError.get();
@@ -239,7 +240,7 @@ public class HttpRequestAttempt<T> {
         }
 
         try {
-            T deserialized = apiClient.getObjectMapper().readValue(response.body(), clazz);
+            T deserialized = apiClient.getJsonSerializer().readValue(response.body(), clazz);
             return CompletableFuture.completedFuture(deserialized);
         } catch (IOException e) {
             // Malformed response.

--- a/src/main/java/dev/openfga/sdk/api/client/Jackson2JsonSerializer.java
+++ b/src/main/java/dev/openfga/sdk/api/client/Jackson2JsonSerializer.java
@@ -1,0 +1,86 @@
+package dev.openfga.sdk.api.client;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.openfga.sdk.errors.SdkSerializationException;
+import java.io.IOException;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+
+/** Serializes SDK values with Jackson 2. */
+final class Jackson2JsonSerializer implements JsonSerializer {
+    private final ObjectMapper objectMapper;
+
+    Jackson2JsonSerializer() {
+        this(createDefaultObjectMapper());
+    }
+
+    Jackson2JsonSerializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    @Override
+    public byte[] writeValueAsBytes(Object value) throws SdkSerializationException {
+        try {
+            return objectMapper.writeValueAsBytes(value);
+        } catch (IOException error) {
+            throw new SdkSerializationException("Cannot serialize JSON value", error);
+        }
+    }
+
+    @Override
+    public <T> T readValue(byte[] source, Class<T> type) throws SdkSerializationException {
+        try {
+            return objectMapper.readValue(source, type);
+        } catch (IOException error) {
+            throw new SdkSerializationException("Cannot deserialize JSON value", error);
+        }
+    }
+
+    @Override
+    public <T> T readValue(String source, Class<T> type) throws SdkSerializationException {
+        try {
+            return objectMapper.readValue(source, type);
+        } catch (IOException error) {
+            throw new SdkSerializationException("Cannot deserialize JSON value", error);
+        }
+    }
+
+    @Override
+    public <T> T readValue(byte[] source, SdkTypeToken<T> type) throws SdkSerializationException {
+        try {
+            return objectMapper.readValue(source, objectMapper.getTypeFactory().constructType(type.getType()));
+        } catch (IOException error) {
+            throw new SdkSerializationException("Cannot deserialize JSON value", error);
+        }
+    }
+
+    @Override
+    public <T> T readValue(String source, SdkTypeToken<T> type) throws SdkSerializationException {
+        try {
+            return objectMapper.readValue(source, objectMapper.getTypeFactory().constructType(type.getType()));
+        } catch (IOException error) {
+            throw new SdkSerializationException("Cannot deserialize JSON value", error);
+        }
+    }
+
+    static ObjectMapper createDefaultObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
+        objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+        objectMapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new JsonNullableModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/dev/openfga/sdk/api/client/JsonSerializer.java
+++ b/src/main/java/dev/openfga/sdk/api/client/JsonSerializer.java
@@ -1,0 +1,21 @@
+package dev.openfga.sdk.api.client;
+
+import dev.openfga.sdk.errors.SdkSerializationException;
+
+/** Serializes SDK request and response values without exposing a JSON library. */
+public interface JsonSerializer {
+    /** Creates the SDK default serializer. */
+    static JsonSerializer createDefault() {
+        return new Jackson2JsonSerializer();
+    }
+
+    byte[] writeValueAsBytes(Object value) throws SdkSerializationException;
+
+    <T> T readValue(byte[] source, Class<T> type) throws SdkSerializationException;
+
+    <T> T readValue(String source, Class<T> type) throws SdkSerializationException;
+
+    <T> T readValue(byte[] source, SdkTypeToken<T> type) throws SdkSerializationException;
+
+    <T> T readValue(String source, SdkTypeToken<T> type) throws SdkSerializationException;
+}

--- a/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
+++ b/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java
@@ -95,13 +95,25 @@ public class OpenFgaClient {
     }
 
     /**
-     * Returns a {@link StreamingApiExecutor} for calling streaming endpoints not yet wrapped by the SDK.
-     * Use when the response type {@code T} is itself generic; otherwise prefer {@link #streamingApiExecutor(Class)}.
+     * Returns a streaming executor for a generic response type.
      *
-     * @param <T>     The type of individual response objects delivered to the consumer
-     * @param typeRef TypeReference for {@code StreamResult<T>}
-     * @return StreamingApiExecutor instance
+     * @param <T> The response object type
+     * @param type SDK type token for {@code StreamResult<T>}
+     * @return Streaming API executor
      */
+    public <T> StreamingApiExecutor<T> streamingApiExecutor(SdkTypeToken<StreamResult<T>> type) {
+        return new StreamingApiExecutor<>(this.apiClient, this.configuration, type);
+    }
+
+    /**
+     * Returns a streaming executor for a generic response type.
+     *
+     * @param <T> The response object type
+     * @param typeRef Jackson type reference for {@code StreamResult<T>}
+     * @return Streaming API executor
+     * @deprecated Use {@link #streamingApiExecutor(SdkTypeToken)}.
+     */
+    @Deprecated(since = "0.11.0")
     public <T> StreamingApiExecutor<T> streamingApiExecutor(TypeReference<StreamResult<T>> typeRef) {
         return new StreamingApiExecutor<>(this.apiClient, this.configuration, typeRef);
     }

--- a/src/main/java/dev/openfga/sdk/api/client/SdkTypeToken.java
+++ b/src/main/java/dev/openfga/sdk/api/client/SdkTypeToken.java
@@ -1,0 +1,95 @@
+package dev.openfga.sdk.api.client;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+/** Preserves a generic Java type for response deserialization. */
+public abstract class SdkTypeToken<T> {
+    private final Type type;
+
+    protected SdkTypeToken() {
+        Type superclass = getClass().getGenericSuperclass();
+        if (!(superclass instanceof ParameterizedType)) {
+            throw new IllegalArgumentException("SdkTypeToken must include a type parameter");
+        }
+        this.type = ((ParameterizedType) superclass).getActualTypeArguments()[0];
+    }
+
+    private SdkTypeToken(Type type) {
+        this.type = type;
+    }
+
+    /** Creates a token for a non-generic class. */
+    public static <T> SdkTypeToken<T> of(Class<T> type) {
+        return new SimpleTypeToken<>(type);
+    }
+
+    static <T> SdkTypeToken<T> from(Type type) {
+        return new SimpleTypeToken<>(type);
+    }
+
+    /** Creates a token for a parameterized type. */
+    public static <T> SdkTypeToken<T> parameterized(Class<?> rawType, Type... typeArguments) {
+        return new SimpleTypeToken<>(new ParameterizedTypeImpl(rawType, typeArguments));
+    }
+
+    Type getType() {
+        return type;
+    }
+
+    private static final class SimpleTypeToken<T> extends SdkTypeToken<T> {
+        private SimpleTypeToken(Type type) {
+            super(type);
+        }
+    }
+
+    private static final class ParameterizedTypeImpl implements ParameterizedType {
+        private final Class<?> rawType;
+        private final Type[] typeArguments;
+
+        private ParameterizedTypeImpl(Class<?> rawType, Type[] typeArguments) {
+            this.rawType = rawType;
+            this.typeArguments = typeArguments.clone();
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return typeArguments.clone();
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof ParameterizedType)) {
+                return false;
+            }
+            ParameterizedType that = (ParameterizedType) other;
+            return rawType.equals(that.getRawType())
+                    && that.getOwnerType() == null
+                    && Arrays.equals(typeArguments, that.getActualTypeArguments());
+        }
+
+        @Override
+        public int hashCode() {
+            return rawType.hashCode() ^ Arrays.hashCode(typeArguments);
+        }
+
+        @Override
+        public String getTypeName() {
+            return rawType.getTypeName() + "<"
+                    + String.join(
+                            ", ",
+                            Arrays.stream(typeArguments).map(Type::getTypeName).toArray(String[]::new)) + ">";
+        }
+    }
+}

--- a/src/main/java/dev/openfga/sdk/api/client/SdkTypeToken.java
+++ b/src/main/java/dev/openfga/sdk/api/client/SdkTypeToken.java
@@ -34,7 +34,8 @@ public abstract class SdkTypeToken<T> {
         return new SimpleTypeToken<>(new ParameterizedTypeImpl(rawType, typeArguments));
     }
 
-    Type getType() {
+    /** Returns the captured Java type. */
+    public Type getType() {
         return type;
     }
 

--- a/src/main/java/dev/openfga/sdk/api/client/StreamingApiExecutor.java
+++ b/src/main/java/dev/openfga/sdk/api/client/StreamingApiExecutor.java
@@ -1,8 +1,6 @@
 package dev.openfga.sdk.api.client;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.openfga.sdk.api.BaseStreamingApi;
 import dev.openfga.sdk.api.configuration.Configuration;
 import dev.openfga.sdk.api.model.StreamResult;
@@ -27,7 +25,7 @@ import javax.annotation.Nullable;
  *     .thenRun(() -> System.out.println("Done"));
  * }</pre>
  *
- * <p>If the response type is itself generic, use {@link OpenFgaClient#streamingApiExecutor(TypeReference)} instead.</p>
+ * <p>If the response type is generic, use {@link OpenFgaClient#streamingApiExecutor(SdkTypeToken)}.</p>
  */
 public class StreamingApiExecutor<T> extends BaseStreamingApi<T> {
 
@@ -40,37 +38,40 @@ public class StreamingApiExecutor<T> extends BaseStreamingApi<T> {
         this(
                 apiClient,
                 configuration,
-                buildTypeReference(
-                        requireNonNull(apiClient, "ApiClient cannot be null").getObjectMapper(),
-                        requireNonNull(responseType, "Response type cannot be null")));
+                SdkTypeToken.parameterized(
+                        StreamResult.class, requireNonNull(responseType, "Response type cannot be null")));
     }
 
     /**
-     * Use when the response type {@code T} is itself generic.
-     * For concrete types, prefer {@link #StreamingApiExecutor(ApiClient, Configuration, Class)}.
+     * Use when the response type is generic.
      *
-     * @param apiClient     API client for HTTP operations
+     * @param apiClient API client for HTTP operations
      * @param configuration Client configuration
-     * @param typeRef       TypeReference for {@code StreamResult<T>}
+     * @param type SDK type token for {@code StreamResult<T>}
      */
-    public StreamingApiExecutor(
-            ApiClient apiClient, Configuration configuration, TypeReference<StreamResult<T>> typeRef) {
+    public StreamingApiExecutor(ApiClient apiClient, Configuration configuration, SdkTypeToken<StreamResult<T>> type) {
         super(
                 requireNonNull(configuration, "Configuration cannot be null"),
                 requireNonNull(apiClient, "ApiClient cannot be null"),
-                requireNonNull(typeRef, "TypeReference cannot be null"));
+                requireNonNull(type, "SdkTypeToken cannot be null"));
     }
 
-    /** Builds a {@code TypeReference<StreamResult<T>>} from a plain {@code Class<T>}. */
-    private static <T> TypeReference<StreamResult<T>> buildTypeReference(
-            ObjectMapper objectMapper, Class<T> responseType) {
-        JavaType javaType = objectMapper.getTypeFactory().constructParametricType(StreamResult.class, responseType);
-        return new TypeReference<StreamResult<T>>() {
-            @Override
-            public JavaType getType() {
-                return javaType;
-            }
-        };
+    /**
+     * Use when the response type is generic.
+     *
+     * @param apiClient API client for HTTP operations
+     * @param configuration Client configuration
+     * @param typeRef Jackson type reference for {@code StreamResult<T>}
+     * @deprecated Use {@link #StreamingApiExecutor(ApiClient, Configuration, SdkTypeToken)}.
+     */
+    @Deprecated(since = "0.11.0")
+    public StreamingApiExecutor(
+            ApiClient apiClient, Configuration configuration, TypeReference<StreamResult<T>> typeRef) {
+        this(
+                apiClient,
+                configuration,
+                SdkTypeToken.from(
+                        requireNonNull(typeRef, "TypeReference cannot be null").getType()));
     }
 
     /** Throws {@link IllegalArgumentException} if {@code value} is null. */

--- a/src/main/java/dev/openfga/sdk/errors/FgaError.java
+++ b/src/main/java/dev/openfga/sdk/errors/FgaError.java
@@ -2,12 +2,7 @@ package dev.openfga.sdk.errors;
 
 import static dev.openfga.sdk.errors.HttpStatusCode.*;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dev.openfga.sdk.api.client.JsonSerializer;
 import dev.openfga.sdk.api.configuration.Configuration;
 import dev.openfga.sdk.api.configuration.CredentialsMethod;
 import dev.openfga.sdk.constants.FgaConstants;
@@ -15,7 +10,6 @@ import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Optional;
-import org.openapitools.jackson.nullable.JsonNullableModule;
 
 public class FgaError extends ApiException {
     private static final String UNKNOWN_ERROR_CODE = "unknown_error";
@@ -31,21 +25,7 @@ public class FgaError extends ApiException {
     private String apiErrorMessage = null;
     private String operationName = null;
 
-    private static final ObjectMapper OBJECT_MAPPER = createConfiguredObjectMapper();
-
-    private static ObjectMapper createConfiguredObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
-        mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
-        mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
-        mapper.registerModule(new JavaTimeModule());
-        mapper.registerModule(new JsonNullableModule());
-        return mapper;
-    }
+    private static final JsonSerializer DEFAULT_JSON_SERIALIZER = JsonSerializer.createDefault();
 
     @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true)
     private static class ApiErrorResponse {
@@ -97,6 +77,16 @@ public class FgaError extends ApiException {
             Configuration configuration,
             HttpResponse<String> response,
             Throwable previousError) {
+        return getError(name, request, configuration, response, previousError, DEFAULT_JSON_SERIALIZER);
+    }
+
+    public static Optional<FgaError> getError(
+            String name,
+            HttpRequest request,
+            Configuration configuration,
+            HttpResponse<String> response,
+            Throwable previousError,
+            JsonSerializer jsonSerializer) {
         int status = response.statusCode();
 
         // FGA and OAuth2 servers are only expected to return HTTP 2xx responses.
@@ -143,10 +133,10 @@ public class FgaError extends ApiException {
         // Parse API error response
         if (body != null && !body.trim().isEmpty()) {
             try {
-                ApiErrorResponse resp = OBJECT_MAPPER.readValue(body, ApiErrorResponse.class);
+                ApiErrorResponse resp = jsonSerializer.readValue(body, ApiErrorResponse.class);
                 error.setApiErrorCode(resp.getCode());
                 error.setApiErrorMessage(resp.getMessage());
-            } catch (JsonProcessingException e) {
+            } catch (SdkSerializationException e) {
                 // Wrap unparseable response
                 error.setApiErrorCode(UNKNOWN_ERROR_CODE);
                 error.setApiErrorMessage("Unable to parse error response. Raw response: " + body);

--- a/src/main/java/dev/openfga/sdk/errors/SdkSerializationException.java
+++ b/src/main/java/dev/openfga/sdk/errors/SdkSerializationException.java
@@ -1,0 +1,10 @@
+package dev.openfga.sdk.errors;
+
+import java.io.IOException;
+
+/** Reports a failure to serialize or deserialize an SDK value. */
+public class SdkSerializationException extends IOException {
+    public SdkSerializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/dev/openfga/sdk/SdkTypeTokenTest.java
+++ b/src/test/java/dev/openfga/sdk/SdkTypeTokenTest.java
@@ -1,0 +1,21 @@
+package dev.openfga.sdk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import dev.openfga.sdk.api.client.SdkTypeToken;
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SdkTypeTokenTest {
+    @Test
+    void exposesCapturedTypeToExternalSerializer() {
+        SdkTypeToken<List<String>> type = new SdkTypeToken<List<String>>() {};
+
+        ParameterizedType capturedType = assertInstanceOf(ParameterizedType.class, type.getType());
+
+        assertEquals(List.class, capturedType.getRawType());
+        assertEquals(String.class, capturedType.getActualTypeArguments()[0]);
+    }
+}

--- a/src/test/java/dev/openfga/sdk/api/OpenFgaApiTest.java
+++ b/src/test/java/dev/openfga/sdk/api/OpenFgaApiTest.java
@@ -68,7 +68,8 @@ public class OpenFgaApiTest {
         doNothing().when(mockConfiguration).assertValid();
 
         mockApiClient = mock(ApiClient.class);
-        when(mockApiClient.getObjectMapper()).thenReturn(mapper);
+        when(mockApiClient.getJsonSerializer())
+                .thenReturn(new ApiClient().setObjectMapper(mapper).getJsonSerializer());
         when(mockApiClient.getHttpClient()).thenReturn(mockHttpClient);
         when(mockApiClient.getHttpClientBuilder()).thenReturn(mockHttpClientBuilder);
 

--- a/src/test/java/dev/openfga/sdk/api/StreamingApiTest.java
+++ b/src/test/java/dev/openfga/sdk/api/StreamingApiTest.java
@@ -53,7 +53,8 @@ class StreamingApiTest {
         MockitoAnnotations.openMocks(this);
 
         objectMapper = new ObjectMapper();
-        when(mockApiClient.getObjectMapper()).thenReturn(objectMapper);
+        when(mockApiClient.getJsonSerializer())
+                .thenReturn(new ApiClient().setObjectMapper(objectMapper).getJsonSerializer());
         when(mockApiClient.getHttpClient()).thenReturn(mockHttpClient);
 
         when(mockConfiguration.getApiUrl()).thenReturn("https://api.fga.example");

--- a/src/test/java/dev/openfga/sdk/api/auth/OAuth2ClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/auth/OAuth2ClientTest.java
@@ -422,7 +422,8 @@ class OAuth2ClientTest {
 
             apiClient = mock(ApiClient.class);
             when(apiClient.getHttpClient()).thenReturn(mockHttpClient);
-            when(apiClient.getObjectMapper()).thenReturn(mapper);
+            when(apiClient.getJsonSerializer())
+                    .thenReturn(new ApiClient().setObjectMapper(mapper).getJsonSerializer());
         } else {
             apiClient = new ApiClient();
         }

--- a/src/test/java/dev/openfga/sdk/api/client/ApiClientTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/ApiClientTest.java
@@ -55,6 +55,24 @@ class ApiClientTest {
         assertEquals(apiClient.getHttpClient().version(), HttpClient.Version.HTTP_2);
     }
 
+    @Test
+    void objectMapperAccessorsDelegateToJacksonSerializer() {
+        com.fasterxml.jackson.databind.ObjectMapper objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        ApiClient apiClient = new ApiClient(HttpClient.newBuilder(), objectMapper);
+
+        assertEquals(objectMapper, apiClient.getObjectMapper());
+        assertEquals(objectMapper, ((Jackson2JsonSerializer) apiClient.getJsonSerializer()).getObjectMapper());
+    }
+
+    @Test
+    void objectMapperAccessorRejectsCustomSerializer() {
+        JsonSerializer serializer = Mockito.mock(JsonSerializer.class);
+        ApiClient apiClient = new ApiClient(HttpClient.newBuilder(), serializer);
+
+        assertEquals(serializer, apiClient.getJsonSerializer());
+        assertThrows(UnsupportedOperationException.class, apiClient::getObjectMapper);
+    }
+
     @Nested
     class ApplyAuthHeader {
 

--- a/src/test/java/dev/openfga/sdk/api/client/Jackson2JsonSerializerTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/Jackson2JsonSerializerTest.java
@@ -1,0 +1,44 @@
+package dev.openfga.sdk.api.client;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.openfga.sdk.api.model.CheckRequest;
+import dev.openfga.sdk.api.model.CheckRequestTupleKey;
+import dev.openfga.sdk.api.model.ConsistencyPreference;
+import dev.openfga.sdk.api.model.StreamResult;
+import dev.openfga.sdk.api.model.StreamedListObjectsResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class Jackson2JsonSerializerTest {
+    @Test
+    void preservesDefaultRequestBytes() throws Exception {
+        ObjectMapper objectMapper = Jackson2JsonSerializer.createDefaultObjectMapper();
+        Jackson2JsonSerializer serializer = new Jackson2JsonSerializer();
+        CheckRequest request = new CheckRequest()
+                .tupleKey(new CheckRequestTupleKey()
+                        .user("user:anne")
+                        .relation("viewer")
+                        ._object("document:roadmap"))
+                .authorizationModelId("01H0FGA")
+                .context(Map.of("region", "us"))
+                .consistency(ConsistencyPreference.HIGHER_CONSISTENCY);
+
+        assertArrayEquals(objectMapper.writeValueAsBytes(request), serializer.writeValueAsBytes(request));
+    }
+
+    @Test
+    void readsGenericStreamResult() throws Exception {
+        Jackson2JsonSerializer serializer = new Jackson2JsonSerializer();
+        SdkTypeToken<StreamResult<StreamedListObjectsResponse>> type =
+                new SdkTypeToken<StreamResult<StreamedListObjectsResponse>>() {};
+
+        StreamResult<StreamedListObjectsResponse> result = serializer.readValue(
+                "{\"result\":{\"object\":\"document:roadmap\"}}".getBytes(StandardCharsets.UTF_8), type);
+
+        assertEquals("document:roadmap", result.getResult().getObject());
+    }
+}

--- a/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientHeadersTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/OpenFgaClientHeadersTest.java
@@ -55,7 +55,7 @@ public class OpenFgaClientHeadersTest {
 
         var mockApiClient = mock(ApiClient.class);
         when(mockApiClient.getHttpClient()).thenReturn(mockHttpClient);
-        when(mockApiClient.getObjectMapper()).thenReturn(new ObjectMapper());
+        when(mockApiClient.getJsonSerializer()).thenReturn(new Jackson2JsonSerializer(new ObjectMapper()));
         when(mockApiClient.getHttpClientBuilder()).thenReturn(mockHttpClientBuilder);
 
         fga = new OpenFgaClient(clientConfiguration, mockApiClient);

--- a/src/test/java/dev/openfga/sdk/api/client/StreamedListObjectsTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/StreamedListObjectsTest.java
@@ -55,7 +55,7 @@ public class StreamedListObjectsTest {
 
         mockApiClient = mock(ApiClient.class);
         when(mockApiClient.getHttpClient()).thenReturn(mockHttpClient);
-        when(mockApiClient.getObjectMapper()).thenReturn(new ObjectMapper());
+        when(mockApiClient.getJsonSerializer()).thenReturn(new Jackson2JsonSerializer(new ObjectMapper()));
         when(mockApiClient.getHttpClientBuilder()).thenReturn(mockHttpClientBuilder);
 
         fga = new OpenFgaClient(clientConfiguration, mockApiClient);

--- a/src/test/java/dev/openfga/sdk/api/client/StreamingApiExecutorTest.java
+++ b/src/test/java/dev/openfga/sdk/api/client/StreamingApiExecutorTest.java
@@ -60,7 +60,7 @@ public class StreamingApiExecutorTest {
 
         mockApiClient = mock(ApiClient.class);
         when(mockApiClient.getHttpClient()).thenReturn(mockHttpClient);
-        when(mockApiClient.getObjectMapper()).thenReturn(new ObjectMapper());
+        when(mockApiClient.getJsonSerializer()).thenReturn(new Jackson2JsonSerializer(new ObjectMapper()));
         when(mockApiClient.getHttpClientBuilder()).thenReturn(mockHttpClientBuilder);
 
         fga = new OpenFgaClient(clientConfiguration, mockApiClient);
@@ -318,6 +318,24 @@ public class StreamingApiExecutorTest {
 
         List<StreamedListObjectsResponse> received = new ArrayList<>();
         fga.streamingApiExecutor(typeRef).stream(buildStreamedListObjectsRequest(), received::add)
+                .get();
+
+        assertEquals(1, received.size());
+        assertEquals("document:1", received.get(0).getObject());
+    }
+
+    @Test
+    public void streamingApiExecutor_sdkTypeTokenOverload_works() throws Exception {
+        SdkTypeToken<StreamResult<StreamedListObjectsResponse>> type =
+                new SdkTypeToken<StreamResult<StreamedListObjectsResponse>>() {};
+
+        Stream<String> lines = Stream.of("{\"result\":{\"object\":\"document:1\"}}");
+        HttpResponse<Stream<String>> mockResponse = mockStreamResponse(200, lines);
+        when(mockHttpClient.<Stream<String>>sendAsync(any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+        List<StreamedListObjectsResponse> received = new ArrayList<>();
+        fga.streamingApiExecutor(type).stream(buildStreamedListObjectsRequest(), received::add)
                 .get();
 
         assertEquals(1, received.size());


### PR DESCRIPTION
## Description

Adds the Jackson 2 compatibility bridge from the approved Jackson 3 RFC. The SDK now owns its serialization API, while existing mapper APIs continue to work with deprecation warnings.

#### What problem is being solved?

Public SDK APIs and internal request paths depend directly on Jackson 2 types. This prevents a later Jackson 3 migration without an abrupt source break.

#### How is it being solved?

An SDK-owned `JsonSerializer` interface and `SdkTypeToken` hide JSON library types from new APIs. The current implementation delegates to the existing Jackson 2 configuration and preserves its wire format.

#### What changes are made to solve it?

- Add `JsonSerializer`, `SdkTypeToken`, and `SdkSerializationException`.
- Route request, response, error, and streaming JSON handling through the serializer.
- Keep mapper and Jackson `TypeReference` APIs as deprecated compatibility wrappers.
- Add compatibility, generic response, and byte-for-byte wire parity tests.

## References

- https://github.com/openfga/rfcs/pull/36
- https://github.com/openfga/java-sdk/issues/300
- https://github.com/openfga/sdk-generator/pull/728

## Test plan

- `./gradlew build`
- `./gradlew test --tests dev.openfga.sdk.api.client.Jackson2JsonSerializerTest --tests dev.openfga.sdk.api.client.ApiClientTest --tests dev.openfga.sdk.api.client.StreamingApiExecutorTest`
- Clean Java SDK regeneration through `make build-client-java` in `sdk-generator`

## Review Checklist

- [x] I have clicked on "allow edits by maintainers".
- [x] I have added tests to validate the changed behavior.
- [x] The correct base branch is being used.
- [x] Generated-file changes have matching source-template changes in `sdk-generator`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pluggable JSON serialization interface for SDK requests and responses.
  * Added support for type-safe generic response deserialization using SDK type tokens.
  * Added streaming API overloads that accept SDK type tokens.
  * Added standardized serialization error handling.

* **Compatibility**
  * Existing Jackson-based APIs remain available but are deprecated in favor of the new serializer and type-token APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->